### PR TITLE
Honor incoming UUIDs as `id` for new records

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 ## 0.0.3-SNAPSHOT
 
-* Upsert by HRID: Accpet an Incoming Instance UUID on Instance create
+* Accept incoming UUIDs for new records (instances, holdings, items)
 * Shared Inventory upsert: Stop populating match key to `indexTitle`
 * Respond with details about HTTP 500 errors from Inventory Storage
 * POM, Dockerfile upgraded to Java 11

--- a/src/main/java/org/folio/inventoryupdate/UpdatePlanAllHRIDs.java
+++ b/src/main/java/org/folio/inventoryupdate/UpdatePlanAllHRIDs.java
@@ -210,7 +210,9 @@ public class UpdatePlanAllHRIDs extends UpdatePlan {
         promisedHoldingsRecord.onComplete( result -> {
             if (result.succeeded()) {
                 if (result.result() == null) {
-                    record.generateUUID();
+                    if (!record.hasUUID()) {
+                        record.generateUUID();
+                    }
                     record.setTransition(Transaction.CREATE);
                 } else {
                     String existingHoldingsRecordId = result.result().getString("id");
@@ -239,7 +241,9 @@ public class UpdatePlanAllHRIDs extends UpdatePlan {
         promisedItem.onComplete( result -> {
             if (result.succeeded()) {
                 if (result.result() == null) {
-                    record.generateUUID();
+                    if (!record.hasUUID()) {
+                        record.generateUUID();
+                    }
                     record.setTransition(Transaction.CREATE);
                 } else {
                     String existingItemId = result.result().getString("id");

--- a/src/main/java/org/folio/inventoryupdate/UpdatePlanSharedInventory.java
+++ b/src/main/java/org/folio/inventoryupdate/UpdatePlanSharedInventory.java
@@ -228,10 +228,14 @@ public class UpdatePlanSharedInventory extends UpdatePlan {
     private void flagAndIdIncomingHoldingsAndItemsForCreation () {
         logger.debug("Got " + updatingSet.getHoldingsRecords().size() + " incoming holdings records. Instance's ID is currently " + updatingSet.getInstanceUUID());
         for (HoldingsRecord holdingsRecord : updatingSet.getHoldingsRecords()) {
-            holdingsRecord.generateUUID();
+            if (!holdingsRecord.hasUUID()) {
+                holdingsRecord.generateUUID();
+            }
             holdingsRecord.setTransition(Transaction.CREATE);
             for (Item item : holdingsRecord.getItems()) {
-                item.generateUUID();
+                if (!item.hasUUID()) {
+                    item.generateUUID();
+                }
                 item.setTransition(Transaction.CREATE);
             }
         }


### PR DESCRIPTION
  Both upsert by HRID and upsert by matchKey will use the `id`
  of the incoming record if it provides any. If the records has
  no `id` a v4 UUID will be generated.

This applies to Instances, HoldingsRecords and Items. 