### PR TITLE
MODINVUP-42: /inventory-view/instances for instance, holdings, items

### DIFF
--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -5,7 +5,7 @@ packages = org.folio.okapi.common.logging
 filters = threshold
 
 filter.threshold.type = ThresholdFilter
-filter.threshold.level = info
+filter.threshold.level = debug
 
 appenders = console
 
@@ -14,6 +14,6 @@ appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss} [$${FolioLoggingContext:requestid}] [$${FolioLoggingContext:tenantid}] [$${FolioLoggingContext:userid}] [$${FolioLoggingContext:moduleid}] %-5p %-20.20C{1} %m%n
 
-rootLogger.level = info
+rootLogger.level = debug
 rootLogger.appenderRefs = info
 rootLogger.appenderRef.stdout.ref = STDOUT


### PR DESCRIPTION
This gives the correct results but the /inventory-view/instances API
doesn't use the instance hrid index and therefore this results in
a full table scan. It is too slow and therefore this API cannot been used.