### PR TITLE
MODINVUP-49: instance-storage 9.0, holdings-storage 6.0, item-storage 10.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## IN-PROGRESS
+
+* Also support interfaces `instance-storage` `9.0`, `holdings-storage` `6.0`, `item-storage` `10.0` (MODINVUP-49)
+
 ## 2.2.0 2022-07-27
 
 * Provides `inventory-batch-upsert-hrid 1.0`  (MODINVUP-41)

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -215,14 +215,14 @@
   "requires": [
     {
       "id": "instance-storage",
-      "version": "7.4 8.0"
+      "version": "7.4 8.0 9.0"
     },
     { "id": "holdings-storage",
-      "version":  "4.1 5.0"
+      "version":  "4.1 5.0 6.0"
     },
     {
       "id": "item-storage",
-      "version": "8.2 9.0"
+      "version": "8.2 9.0 10.0"
     },
     {
       "id": "instance-preceding-succeeding-titles",


### PR DESCRIPTION
mod-inventory-storage has new major interface versions:

instance-storage 9.0
holdings-storage 6.0
item-storage 10.0

mod-inventory-update is not affected because the incompatible change is in the DELETE all APIs only that is not used by mod-inventory-update.

Only the okapiInterfaces need to be bumped in "requires" section of ModuleDescriptor-template.json