### PR TITLE
Change order of item deletes and creates (MODINVUP-46)

### DIFF
--- a/src/main/java/org/folio/inventoryupdate/UpdatePlan.java
+++ b/src/main/java/org/folio/inventoryupdate/UpdatePlan.java
@@ -399,12 +399,9 @@ public abstract class UpdatePlan {
         return promise.future();
     }
 
-    public Future<Void> doUpdateOrCreateItems(OkapiClient okapiClient) {
+    public Future<Void> doUpdateItems(OkapiClient okapiClient) {
         Promise<Void> promise = Promise.promise();
-        List<Item> itemsToUpdateOrCreate = new ArrayList<>();
-        itemsToUpdateOrCreate.addAll(repository.getItemsToUpdate());
-        itemsToUpdateOrCreate.addAll(repository.getItemsToCreate());
-        InventoryStorage.postItems(okapiClient, itemsToUpdateOrCreate).onComplete(
+        InventoryStorage.postItems(okapiClient, repository.getItemsToUpdate()).onComplete(
                 handler -> {
                     if (handler.succeeded()) {
                         promise.complete();
@@ -415,7 +412,21 @@ public abstract class UpdatePlan {
         return promise.future();
     }
 
-    public Future<Void> doDeleteRelationsItemsHoldings(OkapiClient okapiClient) {
+  public Future<Void> doCreateItems(OkapiClient okapiClient) {
+    Promise<Void> promise = Promise.promise();
+    InventoryStorage.postItems(okapiClient, repository.getItemsToCreate()).onComplete(
+        handler -> {
+          if (handler.succeeded()) {
+            promise.complete();
+          } else {
+            promise.fail(handler.cause().getMessage());
+          }
+        });
+    return promise.future();
+  }
+
+
+  public Future<Void> doDeleteRelationsItemsHoldings(OkapiClient okapiClient) {
         Promise<Void> promise = Promise.promise();
         List<Future> deleteRelationsDeleteItems = new ArrayList<>();
         for (InstanceToInstanceRelation relation : repository.getInstanceRelationsToDelete()) {

--- a/src/main/java/org/folio/inventoryupdate/UpdatePlanAllHRIDs.java
+++ b/src/main/java/org/folio/inventoryupdate/UpdatePlanAllHRIDs.java
@@ -387,15 +387,21 @@ public class UpdatePlanAllHRIDs extends UpdatePlan {
             if (prerequisitesCreated.succeeded()) {
                 doUpdateInstancesAndHoldings(okapiClient).onComplete(instancesAndHoldingsUpdated -> {
                     doCreateInstanceRelations(okapiClient).onComplete(relationsCreated -> {
-                        doUpdateOrCreateItems(okapiClient).onComplete(itemsUpdatedAndCreated ->{
-                            if (prerequisitesCreated.succeeded() && instancesAndHoldingsUpdated.succeeded() && itemsUpdatedAndCreated.succeeded()) {
+                        doUpdateItems(okapiClient).onComplete(itemsUpdated ->{
+                            if (prerequisitesCreated.succeeded() && instancesAndHoldingsUpdated.succeeded() && itemsUpdated.succeeded()) {
                                 doDeleteRelationsItemsHoldings(okapiClient).onComplete(deletes -> {
                                     if (deletes.succeeded()) {
-                                        if (relationsCreated.succeeded()) {
+                                      doCreateItems(okapiClient). onComplete(itemsCreated -> {
+                                        if (itemsCreated.succeeded()) {
+                                          if (relationsCreated.succeeded()) {
                                             promise.complete();
-                                        } else {
+                                          } else {
                                             promise.fail(relationsCreated.cause().getMessage());
+                                          }
+                                        } else {
+                                          promise.fail(itemsCreated.cause().getMessage());
                                         }
+                                      });
                                     } else {
                                         promise.fail(deletes.cause().getMessage());
                                     }
@@ -405,8 +411,8 @@ public class UpdatePlanAllHRIDs extends UpdatePlan {
                                     promise.fail(prerequisitesCreated.cause().getMessage());
                                 } else if (instancesAndHoldingsUpdated.failed()) {
                                     promise.fail(instancesAndHoldingsUpdated.cause().getMessage());
-                                } else if (itemsUpdatedAndCreated.failed()) {
-                                    promise.fail(itemsUpdatedAndCreated.cause().getMessage());
+                                } else if (itemsUpdated.failed()) {
+                                    promise.fail(itemsUpdated.cause().getMessage());
                                 }
                             }
                         });

--- a/src/main/java/org/folio/inventoryupdate/UpdatePlanSharedInventory.java
+++ b/src/main/java/org/folio/inventoryupdate/UpdatePlanSharedInventory.java
@@ -428,8 +428,6 @@ public class UpdatePlanSharedInventory extends UpdatePlan {
                                     error = prerequisites.cause().getMessage();
                                   } else if (instanceAndHoldingsUpdates.failed()) {
                                     error = instanceAndHoldingsUpdates.cause().getMessage();
-                                  } else if (itemUpdates.failed()) {
-                                    error = itemUpdates.cause().getMessage();
                                   } else if (itemCreates.failed()) {
                                     error = itemCreates.cause().getMessage();
                                   }

--- a/src/test/java/org/folio/inventoryupdate/test/InventoryUpdateTestSuite.java
+++ b/src/test/java/org/folio/inventoryupdate/test/InventoryUpdateTestSuite.java
@@ -723,6 +723,31 @@ public class InventoryUpdateTestSuite {
   }
 
   @Test
+  public void upsertByMatchKeyWillFailToCreateItemIfMaterialTypeIsMissing(TestContext testContext) {
+    String instanceHrid = "1";
+    upsertByMatchKey(207, new JsonObject()
+        .put("instance",
+            new InputInstance().setTitle("Initial InputInstance").setInstanceTypeId("12345").setHrid(instanceHrid).setSource("test").getJson())
+        .put("holdingsRecords", new JsonArray()
+            .add(new InputHoldingsRecord().setHrid("HOL-001").setPermanentLocationId(LOCATION_ID_1).setCallNumber("test-cn-1").getJson()
+                .put("items", new JsonArray()
+                    .add(new InputItem().setHrid("ITM-001")
+                        .setStatus(STATUS_UNKNOWN)
+                        .setMaterialTypeId(MATERIAL_TYPE_TEXT)
+                        .setBarcode("BC-001").getJson())
+                    .add(new InputItem().setHrid("ITM-002")
+                        .setStatus(STATUS_UNKNOWN)
+                        .setMaterialTypeId(MATERIAL_TYPE_TEXT)
+                        .setBarcode("BC-002").getJson())))
+            .add(new InputHoldingsRecord().setHrid("HOL-002").setPermanentLocationId(LOCATION_ID_1).setCallNumber("test-cn-2").getJson()
+                .put("items", new JsonArray()
+                    .add(new InputItem().setHrid("ITM-003")
+                        .setStatus(STATUS_UNKNOWN)
+                        .setBarcode("BC-003").getJson())))));
+
+  }
+
+  @Test
   public void upsertByMatchKeyWillUpdateHoldingsAndItems (TestContext testContext) {
     String instanceHrid = "1";
     JsonObject upsertResponseJson = upsertByMatchKey(new JsonObject()


### PR DESCRIPTION
 First creating new items, then deleting obsolete items will cause a unique key violation on the barcode, when a new item and an obsolete item have the same barcode.