### PR TITLE
Adapt to schema changes (breaking) in Inventory Storage (MODINVUP-57)

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "inventory-upsert-hrid",
-      "version": "1.1",
+      "version": "2.0",
       "handlers": [
         {
           "methods": ["PUT", "DELETE"],
@@ -67,7 +67,7 @@
     },
     {
       "id": "inventory-batch-upsert-hrid",
-      "version": "1.0",
+      "version": "2.0",
       "handlers": [
         {
           "methods": ["PUT"],
@@ -109,7 +109,7 @@
     },
     {
       "id": "shared-inventory-upsert-matchkey",
-      "version": "1.2",
+      "version": "2.0",
       "handlers": [
         {
           "methods": ["PUT", "DELETE"],
@@ -171,7 +171,7 @@
     },
     {
       "id": "shared-inventory-batch-upsert-matchkey",
-      "version": "1.0",
+      "version": "2.0",
       "handlers": [
         {
           "methods": ["PUT"],
@@ -215,7 +215,7 @@
   "requires": [
     {
       "id": "instance-storage",
-      "version": "7.4 8.0 9.0"
+      "version": "10.0"
     },
     { "id": "holdings-storage",
       "version":  "4.1 5.0 6.0"
@@ -225,12 +225,24 @@
       "version": "8.2 9.0 10.0"
     },
     {
+      "id": "instance-storage-batch-sync",
+      "version": "2.0"
+    },
+    {
+      "id": "holdings-storage-batch-sync",
+      "version": "1.1"
+    },
+    {
+      "id": "item-storage-batch-sync",
+      "version": "1.0"
+    },
+    {
       "id": "instance-preceding-succeeding-titles",
       "version": "0.2"
     },
     {
       "id": "inventory-view-instance-set",
-      "version": "1.0"
+      "version": "2.0"
     },
     {
       "id": "locations",

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.folio</groupId>
   <artifactId>mod-inventory-update</artifactId>
-  <version>2.3.2-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <name>Inventory Update Module</name>
 
   <licenses>

--- a/ramls/instance-with-hrid.json
+++ b/ramls/instance-with-hrid.json
@@ -49,6 +49,12 @@
           "alternativeTitle": {
             "type": "string",
             "description": "An alternative title for the resource"
+          },
+          "authorityId": {
+            "type": "string",
+            "description": "UUID of authority record that controls an alternative title",
+            "$ref": "raml-util/schemas/uuid.schema",
+            "readonly": true
           }
         }
       },
@@ -66,7 +72,23 @@
       "type": "array",
       "description": "List of series titles associated with the resource (e.g. Harry Potter)",
       "items": {
-        "type": "string"
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "description": "Series title value"
+          },
+          "authorityId": {
+            "type": "string",
+            "description": "UUID of authority record that controls an series title",
+            "$ref": "raml-util/schemas/uuid.schema",
+            "readonly": true
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "value"
+        ]
       },
       "uniqueItems": true
     },
@@ -116,6 +138,11 @@
             "type": "string",
             "description": "Contributor type terms defined by the MARC code list for relators"
           },
+          "authorityId": {
+            "type": "string",
+            "description": "UUID of authority record that controls the contributor",
+            "$ref": "raml-util/schemas/uuid.schema"
+          },
           "primary": {
             "type": "boolean",
             "description": "Whether this is the primary contributor"
@@ -132,7 +159,23 @@
       "type": "array",
       "description": "List of subject headings",
       "items": {
-        "type": "string"
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "description": "Subject heading value"
+          },
+          "authorityId": {
+            "type": "string",
+            "description": "UUID of authority record that controls a subject heading",
+            "$ref": "raml-util/schemas/uuid.schema",
+            "readonly": true
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "value"
+        ]
       },
       "uniqueItems": true
     },

--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -75,6 +75,12 @@
           "alternativeTitle": {
             "type": "string",
             "description": "An alternative title for the resource"
+          },
+          "authorityId": {
+            "type": "string",
+            "description": "UUID of authority record that controls an alternative title",
+            "$ref": "raml-util/schemas/uuid.schema",
+            "readonly": true
           }
         }
       },
@@ -92,7 +98,23 @@
       "type": "array",
       "description": "List of series titles associated with the resource (e.g. Harry Potter)",
       "items": {
-        "type": "string"
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "description": "Series title value"
+          },
+          "authorityId": {
+            "type": "string",
+            "description": "UUID of authority record that controls an series title",
+            "$ref": "raml-util/schemas/uuid.schema",
+            "readonly": true
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "value"
+        ]
       },
       "uniqueItems": true
     },
@@ -142,6 +164,11 @@
             "type": "string",
             "description": "Contributor type terms defined by the MARC code list for relators"
           },
+          "authorityId": {
+            "type": "string",
+            "description": "UUID of authority record that controls the contributor",
+            "$ref": "raml-util/schemas/uuid.schema"
+          },
           "primary": {
             "type": "boolean",
             "description": "Whether this is the primary contributor"
@@ -158,7 +185,23 @@
       "type": "array",
       "description": "List of subject headings",
       "items": {
-        "type": "string"
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "description": "Subject heading value"
+          },
+          "authorityId": {
+            "type": "string",
+            "description": "UUID of authority record that controls a subject heading",
+            "$ref": "raml-util/schemas/uuid.schema",
+            "readonly": true
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "value"
+        ]
       },
       "uniqueItems": true
     },


### PR DESCRIPTION
 - `ìnstance.series` and `instance.subjects` are changing from arrays of strings to arrays of objects.
 - This is a breaking change, and since MIU by and large propagates the Inventory Storage Instance schema one-to-one it requires a major version change for MIU as well - from 2.x to 3.x.
 - MIU fails to declare dependencies on some batch APIs in Inventory Storage (some of which takes part in the upcoming breaking changes). This miss is remedied by this commit as well.
 - The schema for Instance in mod-inventory-storage have had other - non-breaking - changes that will be propagated in MIU as well as of this commit.