### PR TITLE
Upgrade vertx-stack-depchain to 4.4.5 (MODINVUP-78)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM folioci/alpine-jre-openjdk17:latest
 
+# Install latest patch versions of packages: https://pythonspeed.com/articles/security-updates-in-docker/
+USER root
+RUN apk upgrade --no-cache
+USER folio
+
 ENV VERTICLE_FILE mod-inventory-update-fat.jar
 
 # Set the location of the verticles

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.2.4</version>
+        <version>4.4.5</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Upgrade runtime dependencies to an official and supported version.

https://wiki.folio.org/display/TC/JDK+17+and+Java+17 suggests to apk upgrade. Please add

# Install latest patch versions of packages: https://pythonspeed.com/articles/security-updates-in-docker/
USER root
RUN apk upgrade --no-cache
USER folio


to Dockerfile.

Please upgrade vertx-stack-depchain from 4.2.4 to 4.4.5. Version 4.2 is out of support and comes with vulnerable netty version 4.1.73.Final: https://nvd.nist.gov/vuln/detail/CVE-2023-34462