### PR TITLE
Fix schema error (MODINVUP-88)

### DIFF
--- a/ramls/item-with-hrid.json
+++ b/ramls/item-with-hrid.json
@@ -358,7 +358,6 @@
     "required": [
       "materialTypeId",
       "permanentLoanTypeId",
-      "holdingsRecordId",
       "status",
       "hrid"
     ]


### PR DESCRIPTION
- holdingsRecordId is not required in PUT but rather ignored as it is maintained by MIU  (informational fix only, required properties are not enforced by MIU but rather by Inventory Storage)