### PR TITLE
MODINVUP-91: ERROR StatusLogger Log4j2: Add log4j-core to classpath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,16 +23,16 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.4.5</version>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>2.17.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-bom</artifactId>
-        <version>2.17.1</version>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-stack-depchain</artifactId>
+        <version>4.4.5</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
```
java -jar target/mod-inventory-update-fat.jar
ERROR StatusLogger Log4j2 could not find a logging implementation. Please add log4j-core to the classpath. Using SimpleLogger to log to the console...
```

I can reproduce this bug locally and with the latest master branch container folioci/mod-inventory-update:3.2.2-SNAPSHOT.115.

The cause is https://github.com/vert-x3/vertx-dependencies/issues/179 and it can be fixed by moving log4j-bom before vertx-stack-depchain in `<dependencyManagement>` as explained in https://github.com/folio-org/raml-module-builder/blob/v35.1.2/doc/upgrading.md#version-351