### PR TITLE
MODINVUP 18

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -249,6 +249,12 @@
       "version": "3.0"
     }
   ],
+  "optional": [
+    {
+      "id": "orders-storage.po-lines",
+      "version": "12.0"
+    }
+  ],
   "permissionSets": [
     {
       "permissionName": "inventory-upsert-hrid.item.put",

--- a/ramls/hrid-deletion.json
+++ b/ramls/hrid-deletion.json
@@ -10,7 +10,7 @@
     "processing": {
       "description": "Processing instructions, for example delete protection for records.",
       "type": "object",
-      "$ref": "instructions/processing-upsert.json"
+      "$ref": "instructions/processing-deletion.json"
     }
   },
   "required": [

--- a/ramls/instructions/processing-deletion.json
+++ b/ramls/instructions/processing-deletion.json
@@ -9,11 +9,12 @@
       "properties": {
         "blockDeletion": {
           "description": "Prevent deletion of an item, and thus the Instance, if given item property is matched by regex",
+          "type": "object",
+          "$ref": "record-retention.json"
+        },
+        "statisticalCoding": {
           "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "record-retention.json"
-          }
+          "$ref": "statistical-coding.json"
         }
       }
     },
@@ -23,11 +24,12 @@
       "properties": {
         "blockDeletion": {
           "description": "Prevent deletion of a holdings record, and thus the Instance, if given holdings record property is matched by regex",
+          "type": "object",
+          "$ref": "record-retention.json"
+        },
+        "statisticalCoding": {
           "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "record-retention.json"
-          }
+          "$ref": "statistical-coding.json"
         }
       }
     },
@@ -37,11 +39,12 @@
       "properties": {
         "blockDeletion": {
           "description": "Prevent deletion of an Instance, if given Instance property is matched by regex",
+          "type": "object",
+          "$ref": "record-retention.json"
+        },
+        "statisticalCoding": {
           "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "record-retention.json"
-          }
+          "$ref": "statistical-coding.json"
         }
       }
     }

--- a/ramls/instructions/processing-deletion.json
+++ b/ramls/instructions/processing-deletion.json
@@ -13,7 +13,7 @@
           "$ref": "record-retention.json"
         },
         "statisticalCoding": {
-          "description": "Configures the statistical code to set on the item for given events",
+          "description": "Configures the statistical codes to set on the item for given events",
           "type": "array",
           "$ref": "statistical-coding.json"
         }

--- a/ramls/instructions/processing-deletion.json
+++ b/ramls/instructions/processing-deletion.json
@@ -13,6 +13,7 @@
           "$ref": "record-retention.json"
         },
         "statisticalCoding": {
+          "description": "Configures the statistical code to set on the item for given events",
           "type": "array",
           "$ref": "statistical-coding.json"
         }
@@ -28,6 +29,7 @@
           "$ref": "record-retention.json"
         },
         "statisticalCoding": {
+          "description": "Configures the statistical code to set on the holdings record for given events",
           "type": "array",
           "$ref": "statistical-coding.json"
         }
@@ -43,6 +45,7 @@
           "$ref": "record-retention.json"
         },
         "statisticalCoding": {
+          "description": "Configures the statistical code to set on the instance for given events",
           "type": "array",
           "$ref": "statistical-coding.json"
         }

--- a/ramls/instructions/processing-upsert.json
+++ b/ramls/instructions/processing-upsert.json
@@ -9,11 +9,8 @@
       "properties": {
         "retainOmittedRecord": {
           "description": "Prevent deletion of item (even though it is omitted from input) if given item property is matched by regex",
-          "type": "array",
-          "items": {
-            "type": "object",
-            "$ref": "record-retention.json"
-          }
+          "type": "object",
+          "$ref": "record-retention.json"
         },
         "retainExistingValues": {
           "description": "Instructions for value retention on updates.",
@@ -72,6 +69,10 @@
           "required": [
             "policy"
           ]
+        },
+        "statisticalCoding": {
+          "type": "array",
+          "$ref": "statistical-coding.json"
         }
       }
     },
@@ -83,6 +84,10 @@
           "description": "Instructions for value retention on updates.",
           "type": "object",
           "$ref": "properties-retention.json"
+        },
+        "statisticalCoding": {
+          "type": "array",
+          "$ref": "statistical-coding.json"
         }
       }
     },
@@ -94,6 +99,10 @@
           "description": "Instructions for value retention on updates.",
           "type": "object",
           "$ref": "properties-retention.json"
+        },
+        "statisticalCoding": {
+          "type": "array",
+          "$ref": "statistical-coding.json"
         }
       }
     }

--- a/ramls/instructions/processing-upsert.json
+++ b/ramls/instructions/processing-upsert.json
@@ -71,6 +71,7 @@
           ]
         },
         "statisticalCoding": {
+          "description": "Configures the statistical codes to set on the item for given events",
           "type": "array",
           "$ref": "statistical-coding.json"
         }
@@ -86,6 +87,7 @@
           "$ref": "properties-retention.json"
         },
         "statisticalCoding": {
+          "description": "Configures the statistical codes to set on the holdings record for given events",
           "type": "array",
           "$ref": "statistical-coding.json"
         }
@@ -101,6 +103,7 @@
           "$ref": "properties-retention.json"
         },
         "statisticalCoding": {
+          "description": "Configures the statistical codes to set on the instance for given events",
           "type": "array",
           "$ref": "statistical-coding.json"
         }

--- a/ramls/instructions/statistical-coding.json
+++ b/ramls/instructions/statistical-coding.json
@@ -1,0 +1,29 @@
+{
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "if": {
+        "type": "string",
+        "description": "The event triggering a statistical coding; currently only one supported event",
+        "enum": [
+          "deleteSkipped"
+        ]
+      },
+      "becauseOf": {
+        "type": "string",
+        "description": "The cause of the event",
+        "enum": [
+          "ITEM_STATUS",
+          "ITEM_PATTERN_MATCH",
+          "HOLDINGS_RECORD_PATTERN_MATCH",
+          "PO_LINE_REFERENCE"
+        ]
+      },
+      "setCode": {
+        "type": "string",
+        "description": "The UUID of the statistical code to set on the inventory record"
+      }
+    }
+  }
+}

--- a/ramls/instructions/statistical-coding.json
+++ b/ramls/instructions/statistical-coding.json
@@ -1,5 +1,6 @@
 {
   "type": "array",
+  "description": "Configures the statistical code to set for the given events",
   "items": {
     "type": "object",
     "properties": {

--- a/src/main/java/org/folio/inventoryupdate/InventoryStorage.java
+++ b/src/main/java/org/folio/inventoryupdate/InventoryStorage.java
@@ -173,7 +173,7 @@ public class InventoryStorage {
     return okapiClient.get(queryUri(INSTANCE_STORAGE_PATH, inventoryQuery))
         .map(json -> {
           JsonArray matchingInstances = new JsonObject(json).getJsonArray(INSTANCES);
-          if (matchingInstances.size() == 0) {
+          if (matchingInstances.isEmpty()) {
             return null;
           }
           return matchingInstances.getJsonObject(0);
@@ -273,39 +273,8 @@ public class InventoryStorage {
     });
     return promise.future();
   }
-  public static Future<JsonArray> lookupParentChildRelationships(OkapiClient okapiClient, QueryByListOfIds inventoryQuery) {
-    Promise<JsonArray> promise = Promise.promise();
-    okapiClient.get(INSTANCE_RELATIONSHIP_STORAGE_PATH +"?limit=10000&query=" + inventoryQuery.getURLEncodedQueryString(), res -> {
-      if (res.succeeded()) {
-        JsonObject relationshipsResult = new JsonObject(res.result());
-        JsonArray parentChildRelations = relationshipsResult.getJsonArray(INSTANCE_RELATIONSHIPS);
-        logger.debug("Successfully looked up existing instance relationships, found  " + parentChildRelations.size());
-        promise.complete(parentChildRelations);
-      } else {
-        logger.info("Could not look up existing instance relationships");
-        failure(res.cause(), Entity.INSTANCE_RELATIONSHIP, Transaction.GET, okapiClient.getStatusCode(), promise,
-                INSTANCE_RELATIONSHIP_STORAGE_PATH +"?limit=10000&query=" + inventoryQuery.getURLEncodedQueryString());
-      }
-    });
-    return promise.future();
-  }
 
-  public static Future<JsonArray> lookupTitleSuccessions (OkapiClient okapiClient, QueryByListOfIds inventoryQuery) {
-    Promise<JsonArray> promise = Promise.promise();
-    okapiClient.get(PRECEDING_SUCCEEDING_TITLE_STORAGE_PATH +"?limit=10000&query=" + inventoryQuery.getURLEncodedQueryString(), res -> {
-      if (res.succeeded()) {
-        JsonObject relationshipsResult = new JsonObject(res.result());
-        JsonArray titleSuccessions = relationshipsResult.getJsonArray(PRECEDING_SUCCEEDING_TITLES);
-        logger.debug("Successfully looked up existing title succession relationships, found  " + titleSuccessions.size());
-        promise.complete(titleSuccessions);
-      } else {
-        failure(res.cause(), Entity.INSTANCE_TITLE_SUCCESSION, Transaction.GET, okapiClient.getStatusCode(), promise,
-                PRECEDING_SUCCEEDING_TITLE_STORAGE_PATH +"?limit=10000&query=" + inventoryQuery.getURLEncodedQueryString());
-      }
-    });
-    return promise.future();
 
-  }
 
   public static Future<JsonObject> lookupSingleInventoryRecordSet(OkapiClient okapiClient, InventoryQuery uniqueQuery) {
     return okapiClient.get(INSTANCE_SET_PATH
@@ -415,19 +384,19 @@ public class InventoryStorage {
   }
 
 
-  private static String queryUri(String path, InventoryQuery inventoryQuery) {
+  public static String queryUri(String path, InventoryQuery inventoryQuery) {
     return path + "?query=" + inventoryQuery.getURLEncodedQueryString();
   }
 
-  private static <T> void failure(Throwable cause, Entity entityType, Transaction transaction, int httpStatusCode, Promise<T> promise) {
+  public static <T> void failure(Throwable cause, Entity entityType, Transaction transaction, int httpStatusCode, Promise<T> promise) {
     failure(cause, entityType, transaction, httpStatusCode, promise, null);
   }
 
-  private static <T> void failure(Throwable cause, Entity entityType, Transaction transaction, int httpStatusCode, Promise<T> promise, String contextNote) {
+  public static <T> void failure(Throwable cause, Entity entityType, Transaction transaction, int httpStatusCode, Promise<T> promise, String contextNote) {
     promise.handle(failureFuture(cause, entityType, transaction, httpStatusCode, contextNote));
   }
 
-  private static <T> Future<T> failureFuture(Throwable cause, Entity entityType, Transaction transaction,
+  public static <T> Future<T> failureFuture(Throwable cause, Entity entityType, Transaction transaction,
       int httpStatusCode, String contextNote) {
     return Future.failedFuture(
             new ErrorReport(ErrorReport.ErrorCategory.STORAGE,

--- a/src/main/java/org/folio/inventoryupdate/InventoryStorage.java
+++ b/src/main/java/org/folio/inventoryupdate/InventoryStorage.java
@@ -58,10 +58,7 @@ public class InventoryStorage {
   public static final String TOTAL_RECORDS = "totalRecords";
   public static final String HOLDINGS_RECORDS = "holdingsRecords";
   public static final String ITEMS = "items";
-  public static final String INSTANCE_RELATIONSHIPS = "instanceRelationships";
-  public static final String PRECEDING_SUCCEEDING_TITLES = "precedingSucceedingTitles";
   public static final String LOCATIONS = "locations";
-  public static final String LF = System.lineSeparator();
 
   public static Future<JsonObject> postInventoryRecord (OkapiClient okapiClient, InventoryRecord record) {
     Promise<JsonObject> promise = Promise.promise();
@@ -284,7 +281,7 @@ public class InventoryStorage {
         + "&limit=1&query=" + uniqueQuery.getURLEncodedQueryString())
         .map(result -> {
           var sets = new JsonObject(result).getJsonArray("instanceSets");
-          if (sets.size() == 0) {
+          if (sets.isEmpty()) {
             return null;
           }
           var input = sets.getJsonObject(0);
@@ -307,7 +304,7 @@ public class InventoryStorage {
   }
 
   private static void mergeItemsIntoHoldings(JsonArray holdingsArray, JsonArray items) {
-    if (holdingsArray.size() == 0 || items.size() == 0) {
+    if (holdingsArray.isEmpty() || items.isEmpty()) {
       return;
     }
     Map<String, JsonObject> holdings = new HashMap<>();

--- a/src/main/java/org/folio/inventoryupdate/InventoryStorage.java
+++ b/src/main/java/org/folio/inventoryupdate/InventoryStorage.java
@@ -146,6 +146,20 @@ public class InventoryStorage {
     return promise.future();
   }
 
+  public static Future<JsonObject> putInventoryRecordOutcomeLess (OkapiClient okapiClient, InventoryRecord record) {
+    Promise<JsonObject> promise = Promise.promise();
+    logger.debug("Putting " + record.entityType() + ": " + record.asJson().encodePrettily());
+    okapiClient.request(HttpMethod.PUT, getApi(record.entityType())+"/"+record.getUUID(), record.asJsonString(), putResult -> {
+      if (putResult.succeeded()) {
+        promise.complete(record.asJson());
+      } else {
+        record.logError(okapiClient.getResponsebody(), okapiClient.getStatusCode(), ErrorReport.ErrorCategory.STORAGE, record.getOriginJson());
+        promise.fail(record.getErrorAsJson().encodePrettily());
+      }
+    });
+    return promise.future();
+  }
+
   public static Future<JsonObject> deleteInventoryRecord (OkapiClient okapiClient, InventoryRecord record) {
     Promise<JsonObject> promise = Promise.promise();
     okapiClient.delete(getApi(record.entityType())+"/"+record.getUUID(), deleteResult -> {

--- a/src/main/java/org/folio/inventoryupdate/InventoryUpdateService.java
+++ b/src/main/java/org/folio/inventoryupdate/InventoryUpdateService.java
@@ -13,6 +13,7 @@ import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.JsonArray;
 import org.folio.inventoryupdate.entities.RecordIdentifiers;
 import org.folio.inventoryupdate.entities.InventoryRecordSet;
+import org.folio.inventoryupdate.instructions.ProcessingInstructionsDeletion;
 import org.folio.okapi.common.OkapiClient;
 
 import io.vertx.core.json.JsonObject;

--- a/src/main/java/org/folio/inventoryupdate/ProcessingInstructionsDeletion.java
+++ b/src/main/java/org/folio/inventoryupdate/ProcessingInstructionsDeletion.java
@@ -53,12 +53,8 @@ public class ProcessingInstructionsDeletion {
       }
     }
 
-    public boolean hasInstructions() {
-      return processing != null && processing.containsKey(key);
-    }
-
-    public boolean retainRecord(InventoryRecord inventoryRecord) {
-      return recordRetention.retain(inventoryRecord);
+    public void setDeleteProtectionIfAny(InventoryRecord inventoryRecord) {
+      recordRetention.setDeleteProtection(inventoryRecord);
     }
   }
 
@@ -77,9 +73,11 @@ public class ProcessingInstructionsDeletion {
       }
     }
 
-    boolean retain (InventoryRecord inventoryRecord) {
-      return inventoryRecord.asJson().getString(field) != null
-          && inventoryRecord.asJson().getString(field).matches(pattern);
+    void setDeleteProtection(InventoryRecord inventoryRecord) {
+      if (inventoryRecord.asJson().getString(field) != null
+          && inventoryRecord.asJson().getString(field).matches(pattern)) {
+         inventoryRecord.registerConstraint(InventoryRecord.DeletionConstraint.IS_DELETE_PROTECTED_PER_INSTRUCTIONS);
+      }
     }
   }
 

--- a/src/main/java/org/folio/inventoryupdate/UpdatePlan.java
+++ b/src/main/java/org/folio/inventoryupdate/UpdatePlan.java
@@ -441,11 +441,17 @@ public abstract class UpdatePlan {
         for (Item item : repository.getItemsToDelete()) {
             deleteRelationsDeleteItems.add(InventoryStorage.deleteInventoryRecord(okapiClient, item));
         }
+        for (Item item : repository.getDeletingItemsToSilentlyUpdate()) {
+            deleteRelationsDeleteItems.add(InventoryStorage.putInventoryRecordOutcomeLess(okapiClient,item));
+        }
         CompositeFuture.join(deleteRelationsDeleteItems).onComplete ( relationshipsAndItemsDeleted -> {
             if (relationshipsAndItemsDeleted.succeeded()) {
                 List<Future> deleteHoldingsRecords = new ArrayList<>();
                 for (HoldingsRecord holdingsRecord : repository.getHoldingsToDelete()) {
                     deleteHoldingsRecords.add(InventoryStorage.deleteInventoryRecord(okapiClient, holdingsRecord));
+                }
+                for (HoldingsRecord holdingsRecord : repository.getDeletingHoldingsToSilentlyUpdate()) {
+                   deleteHoldingsRecords.add(InventoryStorage.putInventoryRecordOutcomeLess(okapiClient, holdingsRecord));
                 }
                 CompositeFuture.join(deleteHoldingsRecords).onComplete( holdingsDeleted -> {
                     if (holdingsDeleted.succeeded()) {

--- a/src/main/java/org/folio/inventoryupdate/UpdatePlan.java
+++ b/src/main/java/org/folio/inventoryupdate/UpdatePlan.java
@@ -14,6 +14,7 @@ import io.vertx.ext.web.RoutingContext;
 import org.folio.inventoryupdate.entities.*;
 import org.folio.inventoryupdate.entities.InventoryRecord.Entity;
 import org.folio.inventoryupdate.entities.InventoryRecord.Transaction;
+import org.folio.inventoryupdate.instructions.ProcessingInstructionsDeletion;
 import org.folio.okapi.common.OkapiClient;
 
 import io.vertx.core.CompositeFuture;
@@ -43,7 +44,7 @@ import static org.folio.inventoryupdate.InventoryUpdateOutcome.OK;
  * and pick up the error messages along the way. If it thus completes with partial success, it should
  * have updated whatever it could and should return an error code - typically 422 -- and display
  * the error condition in the response.
- * Or, put another way, even if the request results in a HTTP error response code, some Inventory
+ * Or, put another way, even if the request results in an HTTP error response code, some Inventory
  * records may have been successfully updated during the processing of the request.
  *
  */
@@ -273,7 +274,6 @@ public abstract class UpdatePlan {
 
     public abstract RequestValidation validateIncomingRecordSet (JsonObject inventoryRecordSet);
 
-
     /**
      * Set transaction type and ID for the instance
      */
@@ -312,11 +312,22 @@ public abstract class UpdatePlan {
         return foundExistingRecordSet() ? existingSet.getItemsByTransactionType(Transaction.DELETE) : new ArrayList<>();
     }
 
+    public List<Item> itemsToSilentlyUpdate () {
+      return foundExistingRecordSet() ? existingSet.getItemsForSilentUpdate() : new ArrayList<>();
+    }
+
+
+
     public List<HoldingsRecord> holdingsToDelete () {
         return foundExistingRecordSet() ? existingSet.getHoldingsRecordsByTransactionType(Transaction.DELETE) : new ArrayList<>();
     }
 
-    public List<InstanceToInstanceRelation> instanceRelationsToDelete() {
+    public List<HoldingsRecord> holdingsRecordsToSilentlyUpdate () {
+      return foundExistingRecordSet() ? existingSet.getHoldingsRecordsForSilentUpdate() : new ArrayList<>();
+    }
+
+
+  public List<InstanceToInstanceRelation> instanceRelationsToDelete() {
         return foundExistingRecordSet() ? existingSet.getInstanceRelationsByTransactionType(Transaction.DELETE) : new ArrayList<>();
     }
 
@@ -488,6 +499,9 @@ public abstract class UpdatePlan {
         for (Item item : itemsToDelete()) {
             deleteRelationsDeleteItems.add(InventoryStorage.deleteInventoryRecord(okapiClient, item));
         }
+        for (Item item : itemsToSilentlyUpdate()) {
+            deleteRelationsDeleteItems.add(InventoryStorage.putInventoryRecordOutcomeLess(okapiClient, item));
+        }
 
         CompositeFuture.join(deleteRelationsDeleteItems).onComplete ( allRelationshipsDoneAllItemsDone -> {
             if (allRelationshipsDoneAllItemsDone.succeeded()) {
@@ -495,16 +509,30 @@ public abstract class UpdatePlan {
                 for (HoldingsRecord holdingsRecord : holdingsToDelete()) {
                     deleteHoldingsRecords.add(InventoryStorage.deleteInventoryRecord(okapiClient, holdingsRecord));
                 }
+                for (HoldingsRecord holdingsRecord : holdingsRecordsToSilentlyUpdate()) {
+                  deleteHoldingsRecords.add(InventoryStorage.putInventoryRecordOutcomeLess(okapiClient, holdingsRecord));
+                }
                 CompositeFuture.join(deleteHoldingsRecords).onComplete( allHoldingsDone -> {
                     if (allHoldingsDone.succeeded()) {
-                        if (isInstanceDeleting() && !getExistingInstance().skipped()) {
+                        if (isInstanceDeleting()) {
+                          if (getExistingInstance().skipped()) {
+                            InventoryStorage.putInventoryRecordOutcomeLess(okapiClient, getExistingInstance()).onComplete(
+                                handler -> {
+                                  if (handler.succeeded()) {
+                                    promise.complete();
+                                  } else {
+                                    promise.fail(handler.cause().getMessage());
+                                  }
+                                }
+                            );
+                          } else {
                             InventoryStorage.deleteInventoryRecord(okapiClient, getExistingRecordSet().getInstance()).onComplete( handler -> {
                                 if (handler.succeeded()) {
                                     promise.complete();
                                 } else {
                                     promise.fail(handler.cause().getMessage());
                                 }
-                            });
+                            });}
                         } else {
                             promise.complete();
                         }

--- a/src/main/java/org/folio/inventoryupdate/UpdatePlanAllHRIDs.java
+++ b/src/main/java/org/folio/inventoryupdate/UpdatePlanAllHRIDs.java
@@ -249,7 +249,6 @@ public class UpdatePlanAllHRIDs extends UpdatePlan {
                                 existingItem.setTransition(DELETE);
                                 // unless item matches an instruction to keep omitted items
                                 if (rules.forItem().retainOmittedRecord(existingItem)) {
-                                  logger.info("Retain omitted item");
                                   existingItem.handleDeleteProtection(InventoryRecord.DeletionConstraint.ITEM_PATTERN_MATCH);
                                   existingItem.skip();
                                   existingHoldingsRecord.handleDeleteProtection(InventoryRecord.DeletionConstraint.ITEM_PATTERN_MATCH);

--- a/src/main/java/org/folio/inventoryupdate/UpdatePlanSharedInventory.java
+++ b/src/main/java/org/folio/inventoryupdate/UpdatePlanSharedInventory.java
@@ -19,6 +19,7 @@ import org.folio.inventoryupdate.entities.Item;
 import org.folio.inventoryupdate.entities.InventoryRecord.Transaction;
 import org.folio.inventoryupdate.entities.Repository;
 import org.folio.inventoryupdate.entities.RepositoryByMatchKey;
+import org.folio.inventoryupdate.instructions.ProcessingInstructionsDeletion;
 import org.folio.okapi.common.OkapiClient;
 
 import io.vertx.core.Future;

--- a/src/main/java/org/folio/inventoryupdate/entities/HoldingsRecord.java
+++ b/src/main/java/org/folio/inventoryupdate/entities/HoldingsRecord.java
@@ -29,7 +29,7 @@ public class HoldingsRecord extends InventoryRecord {
         setItemsHoldingsRecordId(uuid);
     }
 
-    @Override
+  @Override
     public String generateUUID () {
         String uuid = super.generateUUID();
         setItemsHoldingsRecordId(uuid);
@@ -91,6 +91,14 @@ public class HoldingsRecord extends InventoryRecord {
         jsonRecord.remove("bareHoldingsItems");
         jsonRecord.remove("holdingsInstance");
     }
+
+  @Override
+  public void prepareCheckedDeletion() {
+    setTransition(Transaction.DELETE);
+    if (recordRetention.isDeleteProtectedByPatternMatch(this)) {
+      handleDeleteProtection(DeletionConstraint.HOLDINGS_RECORD_PATTERN_MATCH);
+    }
+  }
 
 
 }

--- a/src/main/java/org/folio/inventoryupdate/entities/Instance.java
+++ b/src/main/java/org/folio/inventoryupdate/entities/Instance.java
@@ -6,6 +6,7 @@ import java.util.List;
 import io.vertx.core.json.JsonObject;
 import org.folio.inventoryupdate.MatchKey;
 
+
 public class Instance extends InventoryRecord {
 
     public static final String MATCH_KEY = "matchKey";
@@ -36,7 +37,11 @@ public class Instance extends InventoryRecord {
         setHoldingsRecordsInstanceId(uuid);
     }
 
-    @Override
+
+  @Override
+  public void prepareCheckedDeletion() {}
+
+  @Override
     public String generateUUID () {
         String uuid = super.generateUUID();
         setHoldingsRecordsInstanceId(uuid);

--- a/src/main/java/org/folio/inventoryupdate/entities/InstanceRelationship.java
+++ b/src/main/java/org/folio/inventoryupdate/entities/InstanceRelationship.java
@@ -1,6 +1,7 @@
 package org.folio.inventoryupdate.entities;
 
 import io.vertx.core.json.JsonObject;
+
 public class InstanceRelationship extends InstanceToInstanceRelation {
 
     private String instanceId;
@@ -64,18 +65,19 @@ public class InstanceRelationship extends InstanceToInstanceRelation {
         return jsonRecord.getString(SUPER_INSTANCE_ID);
     }
 
-    public String getInstanceRelationshipTypeId () {
-        return jsonRecord.getString(INSTANCE_RELATIONSHIP_TYPE_ID);
-    }
 
-    public void skipDependants() {
+  @Override
+  public void prepareCheckedDeletion() {
+      throw new UnsupportedOperationException("Checked deletion not implemented for instance relationships");
+  }
+
+  public void skipDependants() {
         // relationships have no dependants in the database
     }
 
     @Override
     public boolean equals (Object o) {
-        if (o instanceof InstanceRelationship) {
-            InstanceRelationship other = (InstanceRelationship) o;
+        if (o instanceof InstanceRelationship other) {
             return other.toString().equals(this.toString());
         } else {
             return false;

--- a/src/main/java/org/folio/inventoryupdate/entities/InstanceTitleSuccession.java
+++ b/src/main/java/org/folio/inventoryupdate/entities/InstanceTitleSuccession.java
@@ -4,7 +4,6 @@ import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.json.JsonObject;
 
-
 public class InstanceTitleSuccession extends InstanceToInstanceRelation {
 
     public static final String ID = "id";
@@ -52,15 +51,19 @@ public class InstanceTitleSuccession extends InstanceToInstanceRelation {
         return instanceRelationClass.equals(InstanceRelationsClass.TO_SUCCEEDING);
     }
 
-    @Override
+  @Override
+  public void prepareCheckedDeletion() {
+    throw new UnsupportedOperationException("Checked deletion not implemented for instance relationships");
+  }
+
+  @Override
     public void skipDependants() {
         // relations have no dependants
     }
 
     @Override
     public boolean equals (Object o) {
-        if (o instanceof InstanceTitleSuccession) {
-            InstanceTitleSuccession other = (InstanceTitleSuccession) o;
+        if (o instanceof InstanceTitleSuccession other) {
             return other.toString().equals(this.toString());
         } else {
             return false;
@@ -73,10 +76,9 @@ public class InstanceTitleSuccession extends InstanceToInstanceRelation {
     }
 
     public String toString () {
-        StringBuilder str = new StringBuilder();
-        str.append("// Preceding: ").append(jsonRecord.getString(PRECEDING_INSTANCE_ID))
-                .append(" Succeeding: ").append(jsonRecord.getString(SUCCEEDING_INSTANCE_ID));
-        return str.toString();
+        String str = "// Preceding: " + jsonRecord.getString(PRECEDING_INSTANCE_ID) +
+                " Succeeding: " + jsonRecord.getString(SUCCEEDING_INSTANCE_ID);
+        return str;
     }
 
 }

--- a/src/main/java/org/folio/inventoryupdate/entities/InventoryRecord.java
+++ b/src/main/java/org/folio/inventoryupdate/entities/InventoryRecord.java
@@ -10,7 +10,9 @@ import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.folio.inventoryupdate.ErrorReport;
-import org.folio.inventoryupdate.ProcessingInstructionsUpsert;
+import org.folio.inventoryupdate.instructions.ProcessingInstructionsUpsert;
+import org.folio.inventoryupdate.instructions.RecordRetention;
+import org.folio.inventoryupdate.instructions.StatisticalCoding;
 
 import static org.folio.inventoryupdate.ErrorReport.UNPROCESSABLE_ENTITY;
 
@@ -49,11 +51,10 @@ public abstract class InventoryRecord {
     }
 
     public enum DeletionConstraint {
-        REFERENCED_BY_PURCHASE_ORDER_LINE,
-        ITEM_REFERENCED_BY_CIRCULATION,
-        REFERENCED_BY_DELETE_PROTECTED_HOLDINGS_RECORD,
-        REFERENCED_BY_DELETE_PROTECTED_ITEM,
-        IS_DELETE_PROTECTED_PER_INSTRUCTIONS
+      PO_LINE_REFERENCE,
+      ITEM_STATUS,
+      HOLDINGS_RECORD_PATTERN_MATCH,
+      ITEM_PATTERN_MATCH
     }
 
     protected JsonObject jsonRecord;
@@ -67,9 +68,16 @@ public abstract class InventoryRecord {
     private static final String ERRORS = "errors";
     private static final String PARAMETERS = "parameters";
 
+    private static final String STATISTICAL_CODE_IDS = "statisticalCodeIds";
+
     protected static final Logger logger = LoggerFactory.getLogger("inventory-update");
 
     private final List<DeletionConstraint> deletionConstraints = new ArrayList<>();
+
+    StatisticalCoding statisticalCoding;
+    RecordRetention recordRetention;
+
+    Boolean updateSilently = false;
 
     public InventoryRecord setTransition (Transaction transaction) {
         this.transaction = transaction;
@@ -92,12 +100,19 @@ public abstract class InventoryRecord {
         return (transaction == Transaction.UPDATE);
     }
 
-    public boolean hasDeleteConstraints() {
-      return !deletionConstraints.isEmpty();
+    public void setDeleteInstructions(RecordRetention recordRetention, StatisticalCoding statisticalCoding) {
+      this.statisticalCoding = statisticalCoding;
+      this.recordRetention = recordRetention;
     }
 
-    public void registerConstraint(DeletionConstraint sourceOfConstraint) {
+    public void handleDeleteProtection(DeletionConstraint sourceOfConstraint) {
       deletionConstraints.add(sourceOfConstraint);
+      setStatisticalCode(sourceOfConstraint);
+      skip();
+    }
+
+    public List<DeletionConstraint> getDeleteConstraints() {
+      return deletionConstraints;
     }
 
     public String generateUUID () {
@@ -137,7 +152,28 @@ public abstract class InventoryRecord {
         return this;
     }
 
-    public void removeGetPropertiesDisallowedInPut(JsonObject jsonRecord) {
+    public InventoryRecord setStatisticalCode (String code) {
+      if (!jsonRecord.containsKey(STATISTICAL_CODE_IDS)) {
+        jsonRecord.put(STATISTICAL_CODE_IDS,new JsonArray());
+      }
+      if (!jsonRecord.getJsonArray(STATISTICAL_CODE_IDS).contains(code)) {
+        jsonRecord.getJsonArray(STATISTICAL_CODE_IDS).add(code);
+      }
+      return this;
+    }
+
+    public void setStatisticalCode(DeletionConstraint constraint) {
+      if (statisticalCoding != null) {
+        String statCode = statisticalCoding.getStatisticalCodeId(constraint);
+        if (!statCode.isEmpty()) {
+          setStatisticalCode(statCode);
+          updateSilently = true;
+        }
+      }
+    }
+
+
+  public void removeGetPropertiesDisallowedInPut(JsonObject jsonRecord) {
     }
 
     public void removeProperty(String propertyName) {
@@ -224,6 +260,8 @@ public abstract class InventoryRecord {
     public boolean skipped() {
         return this.outcome == Outcome.SKIPPED;
     }
+
+    public abstract void prepareCheckedDeletion ();
 
     public void logError (String error, int statusCode, ErrorReport.ErrorCategory category, JsonObject originJson) {
         Object message = maybeJson(error);

--- a/src/main/java/org/folio/inventoryupdate/entities/InventoryRecord.java
+++ b/src/main/java/org/folio/inventoryupdate/entities/InventoryRecord.java
@@ -59,6 +59,8 @@ public abstract class InventoryRecord {
 
     protected static final Logger logger = LoggerFactory.getLogger("inventory-update");
 
+    private boolean remoteReferenceFound = false;
+
     public InventoryRecord setTransition (Transaction transaction) {
         this.transaction = transaction;
         return this;
@@ -80,21 +82,29 @@ public abstract class InventoryRecord {
         return (transaction == Transaction.UPDATE);
     }
 
+    public boolean isRemoteReferenceFound() {
+      return remoteReferenceFound;
+    }
+
+    public void setRemoteReferenceFound(boolean remoteReferenceFound) {
+      this.remoteReferenceFound = remoteReferenceFound;
+    }
+
     public String generateUUID () {
-        UUID uuid = UUID.randomUUID();
-        jsonRecord.put("id", uuid.toString());
-        return uuid.toString();
+          UUID uuid = UUID.randomUUID();
+          jsonRecord.put("id", uuid.toString());
+          return uuid.toString();
+      }
+
+    public void generateUUIDIfNotProvided() {
+      if (!hasUUID()) {
+        generateUUID();
+      }
     }
 
-  public void generateUUIDIfNotProvided() {
-    if (!hasUUID()) {
-      generateUUID();
-    }
-  }
-
-  public void setUUID (String uuid) {
-        jsonRecord.put("id", uuid);
-    }
+    public void setUUID (String uuid) {
+          jsonRecord.put("id", uuid);
+      }
 
     public String getUUID() {
         return jsonRecord.getString("id");

--- a/src/main/java/org/folio/inventoryupdate/entities/InventoryRecord.java
+++ b/src/main/java/org/folio/inventoryupdate/entities/InventoryRecord.java
@@ -1,5 +1,7 @@
 package org.folio.inventoryupdate.entities;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 import io.vertx.core.impl.logging.Logger;
@@ -46,6 +48,14 @@ public abstract class InventoryRecord {
         INSTANCE_TITLE_SUCCESSION
     }
 
+    public enum DeletionConstraint {
+        REFERENCED_BY_PURCHASE_ORDER_LINE,
+        ITEM_REFERENCED_BY_CIRCULATION,
+        REFERENCED_BY_DELETE_PROTECTED_HOLDINGS_RECORD,
+        REFERENCED_BY_DELETE_PROTECTED_ITEM,
+        IS_DELETE_PROTECTED_PER_INSTRUCTIONS
+    }
+
     protected JsonObject jsonRecord;
     protected JsonObject originJson;
     public static final String VERSION = "_version";
@@ -59,7 +69,7 @@ public abstract class InventoryRecord {
 
     protected static final Logger logger = LoggerFactory.getLogger("inventory-update");
 
-    private boolean remoteReferenceFound = false;
+    private final List<DeletionConstraint> deletionConstraints = new ArrayList<>();
 
     public InventoryRecord setTransition (Transaction transaction) {
         this.transaction = transaction;
@@ -82,12 +92,12 @@ public abstract class InventoryRecord {
         return (transaction == Transaction.UPDATE);
     }
 
-    public boolean isRemoteReferenceFound() {
-      return remoteReferenceFound;
+    public boolean hasDeleteConstraints() {
+      return !deletionConstraints.isEmpty();
     }
 
-    public void setRemoteReferenceFound(boolean remoteReferenceFound) {
-      this.remoteReferenceFound = remoteReferenceFound;
+    public void registerConstraint(DeletionConstraint sourceOfConstraint) {
+      deletionConstraints.add(sourceOfConstraint);
     }
 
     public String generateUUID () {

--- a/src/main/java/org/folio/inventoryupdate/entities/InventoryRecordSet.java
+++ b/src/main/java/org/folio/inventoryupdate/entities/InventoryRecordSet.java
@@ -12,6 +12,8 @@ import org.folio.inventoryupdate.entities.InventoryRecord.Transaction;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import org.folio.inventoryupdate.instructions.ProcessingInstructionsDeletion;
+import org.folio.inventoryupdate.instructions.ProcessingInstructionsUpsert;
 
 import static org.folio.inventoryupdate.ErrorReport.BAD_REQUEST;
 import static org.folio.inventoryupdate.entities.RecordIdentifiers.OAI_IDENTIFIER;
@@ -194,6 +196,30 @@ public class InventoryRecordSet extends JsonRepresentation {
         }
         return records;
     }
+
+    public List<HoldingsRecord> getHoldingsRecordsForSilentUpdate () {
+      List<HoldingsRecord> records = new ArrayList<>();
+      for (HoldingsRecord record : getHoldingsRecords()) {
+        if (record.updateSilently) {
+          records.add(record);
+        }
+      }
+      return records;
+    }
+
+    public List<Item> getItemsForSilentUpdate () {
+      List<Item> records = new ArrayList<>();
+      for (Item record : getItems()) {
+        if (record.updateSilently) {
+          records.add(record);
+        }
+      }
+      return records;
+    }
+
+
+
+
     public List<HoldingsRecord> getHoldingsRecordsByTransactionType (Transaction transition) {
         List<HoldingsRecord> records = new ArrayList<>();
         for (HoldingsRecord record : getHoldingsRecords()) {
@@ -411,7 +437,30 @@ public class InventoryRecordSet extends JsonRepresentation {
         }
     }
 
-    public String getLocalIdentifierTypeId () {
+  public void setDeleteInstructions(ProcessingInstructionsDeletion deleteInstructions) {
+    getInstance().setDeleteInstructions(deleteInstructions.forInstance().recordRetention, deleteInstructions.forInstance().statisticalCoding);
+    for (HoldingsRecord rec : getHoldingsRecords()) {
+      rec.setDeleteInstructions(deleteInstructions.forHoldingsRecord().recordRetention, deleteInstructions.forHoldingsRecord().statisticalCoding);
+    }
+    for (Item rec : getItems()) {
+      rec.setDeleteInstructions(deleteInstructions.forItem().recordRetention, deleteInstructions.forItem().statisticalCoding);
+    }
+  }
+
+  public void setDeleteInstructions(ProcessingInstructionsUpsert instructions) {
+      getInstance().setDeleteInstructions(instructions.forInstance().recordRetention, instructions.forInstance().statisticalCoding);
+    for (HoldingsRecord rec : getHoldingsRecords()) {
+      rec.setDeleteInstructions(instructions.forHoldingsRecord().recordRetention, instructions.forHoldingsRecord().statisticalCoding);
+    }
+    for (Item rec : getItems()) {
+      rec.setDeleteInstructions(instructions.forItem().recordRetention, instructions.forItem().statisticalCoding);
+    }
+
+
+  }
+
+
+  public String getLocalIdentifierTypeId () {
         return (processing != null ? processing.getString(IDENTIFIER_TYPE_ID) : null);
     }
 

--- a/src/main/java/org/folio/inventoryupdate/entities/InventoryRecordSet.java
+++ b/src/main/java/org/folio/inventoryupdate/entities/InventoryRecordSet.java
@@ -256,10 +256,12 @@ public class InventoryRecordSet extends JsonRepresentation {
         }
     }
 
-
-    public void prepareAllInstanceRelationsForDeletion() {
+    public void prepareInstanceRelationsForDeleteOrSkip() {
         for (InstanceToInstanceRelation relation : getInstanceToInstanceRelations()) {
             relation.setTransition(InventoryRecord.Transaction.DELETE);
+            if (getInstance().isDeleting() && getInstance().skipped()) {
+              relation.skip();
+            }
         }
     }
 

--- a/src/main/java/org/folio/inventoryupdate/entities/Item.java
+++ b/src/main/java/org/folio/inventoryupdate/entities/Item.java
@@ -1,7 +1,7 @@
 package org.folio.inventoryupdate.entities;
 
 import io.vertx.core.json.JsonObject;
-import org.folio.inventoryupdate.ProcessingInstructionsUpsert;
+import org.folio.inventoryupdate.instructions.ProcessingInstructionsUpsert;
 
 import java.util.Arrays;
 import java.util.List;
@@ -63,6 +63,17 @@ public class Item extends InventoryRecord {
       setStatus(existingItem.getStatusName());
     }
     super.applyOverlays(existingItem,instr);
+  }
+
+  @Override
+  public void prepareCheckedDeletion() {
+    setTransition(Transaction.DELETE);
+    if (recordRetention.isDeleteProtectedByPatternMatch(this)) {
+      handleDeleteProtection(DeletionConstraint.ITEM_PATTERN_MATCH);
+    }
+    if (isCirculating()) {
+      handleDeleteProtection(DeletionConstraint.ITEM_STATUS);
+    }
   }
 
   public boolean isCirculating() {

--- a/src/main/java/org/folio/inventoryupdate/entities/Item.java
+++ b/src/main/java/org/folio/inventoryupdate/entities/Item.java
@@ -3,9 +3,22 @@ package org.folio.inventoryupdate.entities;
 import io.vertx.core.json.JsonObject;
 import org.folio.inventoryupdate.ProcessingInstructionsUpsert;
 
+import java.util.Arrays;
+import java.util.List;
+
 public class Item extends InventoryRecord {
 
   public static final String HOLDINGS_RECORD_ID = "holdingsRecordId";
+  private static final List<String> statusesIndicatingCirculatingItem =
+      Arrays.asList("Awaiting delivery",
+        "Awaiting pickup",
+        "Checked out",
+        "Aged to lost",
+        "Claimed returned",
+        "Declared lost",
+        "Paged",
+        "In transit");
+
 
   public Item(JsonObject item, JsonObject originJson) {
     this.jsonRecord = item;
@@ -51,4 +64,9 @@ public class Item extends InventoryRecord {
     }
     super.applyOverlays(existingItem,instr);
   }
-}
+
+  public boolean isCirculating() {
+    return statusesIndicatingCirculatingItem.contains(getStatusName());
+  }
+
+ }

--- a/src/main/java/org/folio/inventoryupdate/entities/Repository.java
+++ b/src/main/java/org/folio/inventoryupdate/entities/Repository.java
@@ -250,6 +250,20 @@ public abstract class Repository {
     return list;
   }
 
+  public List<HoldingsRecord> getDeletingHoldingsToSilentlyUpdate () {
+    List<HoldingsRecord> list = new ArrayList<>();
+    for (PairedRecordSets pair : pairsOfRecordSets) {
+      if (pair.hasExistingRecordSet()) {
+        for (HoldingsRecord holdingsRecord : pair.getExistingRecordSet().getHoldingsRecords()) {
+          if (holdingsRecord.isDeleting() && holdingsRecord.updateSilently) {
+            list.add(holdingsRecord);
+          }
+        }
+      }
+    }
+    return list;
+  }
+
 
   public List<Item> getItemsToUpdate () {
     List<Item> list = new ArrayList<>();
@@ -285,6 +299,20 @@ public abstract class Repository {
       if (pair.hasExistingRecordSet()) {
         for (Item item : pair.getExistingRecordSet().getItems()) {
           if (item.isDeleting() && !item.skipped()) {
+            list.add(item);
+          }
+        }
+      }
+    }
+    return list;
+  }
+
+  public List<Item> getDeletingItemsToSilentlyUpdate() {
+    List<Item> list = new ArrayList<>();
+    for (PairedRecordSets pair : pairsOfRecordSets) {
+      if (pair.hasExistingRecordSet()) {
+        for (Item item : pair.getExistingRecordSet().getItems()) {
+          if (item.isDeleting() && item.updateSilently) {
             list.add(item);
           }
         }

--- a/src/main/java/org/folio/inventoryupdate/foreignconstraints/OrdersStorage.java
+++ b/src/main/java/org/folio/inventoryupdate/foreignconstraints/OrdersStorage.java
@@ -1,0 +1,35 @@
+package org.folio.inventoryupdate.foreignconstraints;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.folio.okapi.common.OkapiClient;
+
+public class OrdersStorage {
+
+  private static final String ORDER_LINES_STORAGE_PATH = "/orders-storage/po-lines";
+  private static final String PURCHASE_ORDER_LINES = "poLines";
+  private static final Logger logger = LoggerFactory.getLogger("inventory-update");
+
+  public static Future<JsonArray> lookupPurchaseOrderLines (OkapiClient okapiClient, String instanceId) {
+    Promise<JsonArray> promise = Promise.promise();
+    okapiClient.get(ORDER_LINES_STORAGE_PATH + "?query=instanceId==" + instanceId)
+        .onComplete(response -> {
+          if (response.succeeded()) {
+            logger.info("ID-NE: got " + response.result());
+            promise.complete(new JsonObject(response.result()).getJsonArray(PURCHASE_ORDER_LINES));
+          } else {
+            if (!response.cause().getMessage().equalsIgnoreCase("404: No suitable module found for path and tenant")) {
+              logger.error("Could not look up purchase order lines at " + ORDER_LINES_STORAGE_PATH + ": " + response.cause().getMessage());
+            }
+            promise.complete(new JsonArray());
+          }
+        });
+    return promise.future();
+  }
+
+}
+

--- a/src/main/java/org/folio/inventoryupdate/foreignconstraints/OrdersStorage.java
+++ b/src/main/java/org/folio/inventoryupdate/foreignconstraints/OrdersStorage.java
@@ -2,8 +2,6 @@ package org.folio.inventoryupdate.foreignconstraints;
 
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
-import io.vertx.core.impl.logging.Logger;
-import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.folio.okapi.common.OkapiClient;
@@ -12,24 +10,17 @@ public class OrdersStorage {
 
   private static final String ORDER_LINES_STORAGE_PATH = "/orders-storage/po-lines";
   private static final String PURCHASE_ORDER_LINES = "poLines";
-  private static final Logger logger = LoggerFactory.getLogger("inventory-update");
 
   public static Future<JsonArray> lookupPurchaseOrderLines (OkapiClient okapiClient, String instanceId) {
     Promise<JsonArray> promise = Promise.promise();
     okapiClient.get(ORDER_LINES_STORAGE_PATH + "?query=instanceId==" + instanceId)
         .onComplete(response -> {
           if (response.succeeded()) {
-            logger.info("ID-NE: got " + response.result());
             promise.complete(new JsonObject(response.result()).getJsonArray(PURCHASE_ORDER_LINES));
           } else {
-            if (!response.cause().getMessage().equalsIgnoreCase("404: No suitable module found for path and tenant")) {
-              logger.error("Could not look up purchase order lines at " + ORDER_LINES_STORAGE_PATH + ": " + response.cause().getMessage());
-            }
             promise.complete(new JsonArray());
           }
         });
     return promise.future();
   }
-
 }
-

--- a/src/main/java/org/folio/inventoryupdate/instructions/ProcessingInstructionsDeletion.java
+++ b/src/main/java/org/folio/inventoryupdate/instructions/ProcessingInstructionsDeletion.java
@@ -1,16 +1,13 @@
-package org.folio.inventoryupdate;
+package org.folio.inventoryupdate.instructions;
 
 import io.vertx.core.json.JsonObject;
-import org.folio.inventoryupdate.entities.InventoryRecord;
 
-public class ProcessingInstructionsDeletion {
+public class ProcessingInstructionsDeletion  {
   JsonObject processing;
   public static final String INSTANCE_INSTRUCTIONS_KEY = "instance";
   public static final String HOLDINGS_INSTRUCTIONS_KEY = "holdingsRecord";
   public static final String ITEM_INSTRUCTIONS_KEY = "item";
-  public static final String BLOCK_DELETION_KEY = "blockDeletion";
-  public static final String RECORD_RETENTION_CRITERION_FIELD = "ifField";
-  public static final String RECORD_RETENTION_CRITERION_PATTERN = "matchesPattern";
+
 
   private final InstanceInstructions instanceInstructions;
   private final ItemInstructions itemInstructions;
@@ -23,63 +20,41 @@ public class ProcessingInstructionsDeletion {
     itemInstructions = new ItemInstructions(processing);
   }
 
-
-  ProcessingInstructionsDeletion.InstanceInstructions forInstance() {
+  public ProcessingInstructionsDeletion.InstanceInstructions forInstance() {
     return instanceInstructions;
   }
 
-  ProcessingInstructionsDeletion.HoldingsRecordInstructions forHoldingsRecord() {
+  public ProcessingInstructionsDeletion.HoldingsRecordInstructions forHoldingsRecord() {
     return holdingsRecordInstructions;
   }
 
-  ProcessingInstructionsDeletion.ItemInstructions forItem() {
+  public ProcessingInstructionsDeletion.ItemInstructions forItem() {
     return itemInstructions;
   }
 
   public static class EntityInstructions {
     String key;
-    ProcessingInstructionsDeletion.RecordRetention recordRetention;
-    JsonObject processing;
+    public RecordRetention recordRetention;
+    public JsonObject processing;
     JsonObject entityInstructionsJson;
+
+    public StatisticalCoding statisticalCoding;
 
     public EntityInstructions(JsonObject processing, String entityInstructionsKey) {
       this.processing = processing;
       this.key = entityInstructionsKey;
       if (processing != null) {
         this.entityInstructionsJson = processing.getJsonObject(entityInstructionsKey);
-        recordRetention = new ProcessingInstructionsDeletion.RecordRetention(entityInstructionsJson);
+        recordRetention = new RecordRetention(entityInstructionsJson);
       } else {
-        recordRetention = new ProcessingInstructionsDeletion.RecordRetention(null);
+        recordRetention = new RecordRetention(null);
       }
+      statisticalCoding = new StatisticalCoding(this.entityInstructionsJson);
     }
 
-    public void setDeleteProtectionIfAny(InventoryRecord inventoryRecord) {
-      recordRetention.setDeleteProtection(inventoryRecord);
-    }
   }
 
 
-  public static class RecordRetention {
-
-    String field = "~";
-    String pattern = "~";
-    RecordRetention(JsonObject json) {
-      if (json != null) {
-        JsonObject recordRetention = json.getJsonObject(BLOCK_DELETION_KEY);
-        if (recordRetention != null) {
-          field = recordRetention.getString(RECORD_RETENTION_CRITERION_FIELD,"~");
-          pattern = recordRetention.getString(RECORD_RETENTION_CRITERION_PATTERN, "~");
-        }
-      }
-    }
-
-    void setDeleteProtection(InventoryRecord inventoryRecord) {
-      if (inventoryRecord.asJson().getString(field) != null
-          && inventoryRecord.asJson().getString(field).matches(pattern)) {
-         inventoryRecord.registerConstraint(InventoryRecord.DeletionConstraint.IS_DELETE_PROTECTED_PER_INSTRUCTIONS);
-      }
-    }
-  }
 
   public static class InstanceInstructions extends ProcessingInstructionsDeletion.EntityInstructions {
     InstanceInstructions(JsonObject processing) {

--- a/src/main/java/org/folio/inventoryupdate/instructions/RecordRetention.java
+++ b/src/main/java/org/folio/inventoryupdate/instructions/RecordRetention.java
@@ -1,0 +1,34 @@
+package org.folio.inventoryupdate.instructions;
+
+import io.vertx.core.json.JsonObject;
+import org.folio.inventoryupdate.entities.InventoryRecord;
+
+public class RecordRetention {
+  public static final String BLOCK_DELETION_KEY = "blockDeletion";
+  public static final String RETAIN_OMITTED_RECORD_KEY = "retainOmittedRecord";
+  public static final String RECORD_RETENTION_CRITERION_FIELD = "ifField";
+  public static final String RECORD_RETENTION_CRITERION_PATTERN = "matchesPattern";
+
+  String field = "~";
+  String pattern = "~";
+
+  RecordRetention(JsonObject json) {
+    if (json != null) {
+      JsonObject recordRetention = null;
+      if (json.containsKey(BLOCK_DELETION_KEY)) {
+        recordRetention = json.getJsonObject(BLOCK_DELETION_KEY);
+      } else if (json.containsKey(RETAIN_OMITTED_RECORD_KEY)) {
+        recordRetention = json.getJsonObject(RETAIN_OMITTED_RECORD_KEY);
+      }
+      if (recordRetention != null) {
+        field = recordRetention.getString(RECORD_RETENTION_CRITERION_FIELD,"~");
+        pattern = recordRetention.getString(RECORD_RETENTION_CRITERION_PATTERN, "~");
+      }
+    }
+  }
+
+  public boolean isDeleteProtectedByPatternMatch(InventoryRecord inventoryRecord) {
+    return (inventoryRecord.asJson().getString(field) != null
+        && inventoryRecord.asJson().getString(field).matches(pattern));
+  }
+}

--- a/src/main/java/org/folio/inventoryupdate/instructions/StatisticalCoding.java
+++ b/src/main/java/org/folio/inventoryupdate/instructions/StatisticalCoding.java
@@ -1,0 +1,31 @@
+package org.folio.inventoryupdate.instructions;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.folio.inventoryupdate.entities.InventoryRecord;
+
+public class StatisticalCoding {
+
+    public static final String STATISTICAL_CODING = "statisticalCoding";
+    private static final String DELETE_SKIPPED_BECAUSE_OF = "becauseOf";
+    private static final String SET_CODE_UUID = "setCode";
+
+    public JsonArray codings = new JsonArray();
+    StatisticalCoding(JsonObject processing) {
+      if (processing != null) {
+        codings = processing.getJsonArray(STATISTICAL_CODING, new JsonArray());
+      }
+    }
+
+    public String getStatisticalCodeId(InventoryRecord.DeletionConstraint constraint) {
+      for (Object entityEventCode : codings) {
+        JsonObject i = (JsonObject) entityEventCode;
+        if (i.getString("if").equalsIgnoreCase("deleteSkipped") && i.getString(DELETE_SKIPPED_BECAUSE_OF).equalsIgnoreCase(constraint.toString())) {
+          return  i.getString(SET_CODE_UUID);
+        }
+      }
+      return "";
+    }
+
+}
+

--- a/src/test/java/org/folio/inventoryupdate/test/StorageValidatorHoldingsRecords.java
+++ b/src/test/java/org/folio/inventoryupdate/test/StorageValidatorHoldingsRecords.java
@@ -2,12 +2,12 @@ package org.folio.inventoryupdate.test;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
-import org.folio.inventoryupdate.test.fakestorage.FakeInventoryStorage;
+import org.folio.inventoryupdate.test.fakestorage.FakeFolioApis;
 import org.folio.inventoryupdate.test.fakestorage.RecordStorage;
 import org.folio.inventoryupdate.test.fakestorage.entitites.InputHoldingsRecord;
 import org.folio.inventoryupdate.test.fakestorage.entitites.InputInstance;
 
-import static org.folio.inventoryupdate.test.fakestorage.FakeInventoryStorage.*;
+import static org.folio.inventoryupdate.test.fakestorage.FakeFolioApis.*;
 
 public class StorageValidatorHoldingsRecords {
 
@@ -27,48 +27,48 @@ public class StorageValidatorHoldingsRecords {
     }
 
     protected void createDependencies() {
-        JsonObject responseOnPOST = FakeInventoryStorage.post(
+        JsonObject responseOnPOST = FakeFolioApis.post(
                 INSTANCE_STORAGE_PATH,
                 new InputInstance().setTitle(INSTANCE_TITLE).setInstanceTypeId("123").setSource("test").getJson());
         existingInstanceId = responseOnPOST.getString("id");
     }
 
     protected void validatePostAndGetById(TestContext testContext) {
-        JsonObject responseOnPOST = FakeInventoryStorage.post(
+        JsonObject responseOnPOST = FakeFolioApis.post(
                 HOLDINGS_STORAGE_PATH,
                 new InputHoldingsRecord().setInstanceId(existingInstanceId).setPermanentLocationId(InventoryUpdateTestSuite.LOCATION_ID_1).setCallNumber(FIRST_CALL_NUMBER).getJson());
         testContext.assertEquals(responseOnPOST.getString("callNumber"), FIRST_CALL_NUMBER);
-        JsonObject responseOnGET = FakeInventoryStorage.getRecordById(HOLDINGS_STORAGE_PATH, responseOnPOST.getString("id"));
+        JsonObject responseOnGET = FakeFolioApis.getRecordById(HOLDINGS_STORAGE_PATH, responseOnPOST.getString("id"));
         testContext.assertEquals(responseOnGET.getString("callNumber"), FIRST_CALL_NUMBER);
     }
 
     protected void validateGetByQueryAndPut(TestContext testContext) {
-        JsonObject responseJson = FakeInventoryStorage.getRecordsByQuery(
+        JsonObject responseJson = FakeFolioApis.getRecordsByQuery(
                 HOLDINGS_STORAGE_PATH,
                 "query="+ RecordStorage.encode("instanceId==\""+ existingInstanceId +"\""));
         testContext.assertEquals(
                 responseJson.getInteger("totalRecords"), 1,"Number of " + RESULT_SET_HOLDINGS_RECORDS + " expected: 1" );
         JsonObject existingRecord = responseJson.getJsonArray(RESULT_SET_HOLDINGS_RECORDS).getJsonObject(0);
         existingRecord.put("callNumber", SECOND_CALL_NUMBER);
-        FakeInventoryStorage.put(HOLDINGS_STORAGE_PATH, existingRecord);
-        JsonObject record = FakeInventoryStorage.getRecordById(HOLDINGS_STORAGE_PATH, existingRecord.getString("id"));
+        FakeFolioApis.put(HOLDINGS_STORAGE_PATH, existingRecord);
+        JsonObject record = FakeFolioApis.getRecordById(HOLDINGS_STORAGE_PATH, existingRecord.getString("id"));
         testContext.assertEquals(record.getString("callNumber"), SECOND_CALL_NUMBER);
     }
 
     protected void validateCanDeleteHoldingsRecordById (TestContext testContext) {
-        JsonObject responseOnPOST = FakeInventoryStorage.post(
+        JsonObject responseOnPOST = FakeFolioApis.post(
                 HOLDINGS_STORAGE_PATH,
                 new InputHoldingsRecord().setPermanentLocationId(InventoryUpdateTestSuite.LOCATION_ID_1).setCallNumber("TEST-CN").setInstanceId(existingInstanceId).getJson());
         testContext.assertEquals(responseOnPOST.getString("callNumber"), "TEST-CN");
-        FakeInventoryStorage.delete(HOLDINGS_STORAGE_PATH, responseOnPOST.getString("id"),200);
+        FakeFolioApis.delete(HOLDINGS_STORAGE_PATH, responseOnPOST.getString("id"),200);
     }
 
     protected void validateCannotPostWithBadInstanceId (TestContext testContext) {
-        JsonObject responseOnPOST = FakeInventoryStorage.post(
+        JsonObject responseOnPOST = FakeFolioApis.post(
                 HOLDINGS_STORAGE_PATH,
                 new InputHoldingsRecord().setInstanceId(NON_EXISTING_INSTANCE_ID).setPermanentLocationId(InventoryUpdateTestSuite.LOCATION_ID_1).setCallNumber(FIRST_CALL_NUMBER).getJson(),
                 500);
-        JsonObject responseJson = FakeInventoryStorage.getRecordsByQuery(
+        JsonObject responseJson = FakeFolioApis.getRecordsByQuery(
                 HOLDINGS_STORAGE_PATH,
                 "query="+ RecordStorage.encode("instanceId==\""+ NON_EXISTING_INSTANCE_ID +"\""));
         testContext.assertEquals(
@@ -77,11 +77,11 @@ public class StorageValidatorHoldingsRecords {
     }
 
     protected void validateCannotPostWithBadLocationId (TestContext testContext) {
-        JsonObject responseOnPOST = FakeInventoryStorage.post(
+        JsonObject responseOnPOST = FakeFolioApis.post(
                 HOLDINGS_STORAGE_PATH,
                 new InputHoldingsRecord().setInstanceId(existingInstanceId).setPermanentLocationId("BAD_LOCATION").setCallNumber(FIRST_CALL_NUMBER).getJson(),
                 500);
-        JsonObject responseJson = FakeInventoryStorage.getRecordsByQuery(
+        JsonObject responseJson = FakeFolioApis.getRecordsByQuery(
                 HOLDINGS_STORAGE_PATH,
                 "query="+ RecordStorage.encode("permanentLocationId==\""+ "BAD_LOCATION" +"\""));
         testContext.assertEquals(

--- a/src/test/java/org/folio/inventoryupdate/test/StorageValidatorInstanceRelationships.java
+++ b/src/test/java/org/folio/inventoryupdate/test/StorageValidatorInstanceRelationships.java
@@ -2,11 +2,11 @@ package org.folio.inventoryupdate.test;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
-import org.folio.inventoryupdate.test.fakestorage.FakeInventoryStorage;
+import org.folio.inventoryupdate.test.fakestorage.FakeFolioApis;
 import org.folio.inventoryupdate.test.fakestorage.entitites.InputInstance;
 import org.folio.inventoryupdate.test.fakestorage.entitites.InputInstanceRelationship;
 
-import static org.folio.inventoryupdate.test.fakestorage.FakeInventoryStorage.*;
+import static org.folio.inventoryupdate.test.fakestorage.FakeFolioApis.*;
 import static org.folio.inventoryupdate.test.fakestorage.entitites.InputInstanceRelationship.*;
 
 public class StorageValidatorInstanceRelationships {
@@ -20,22 +20,22 @@ public class StorageValidatorInstanceRelationships {
     }
 
     protected void createTwoTitles (TestContext testContext) {
-        JsonObject responseOnPOSTChild = FakeInventoryStorage.post(
+        JsonObject responseOnPOSTChild = FakeFolioApis.post(
                 INSTANCE_STORAGE_PATH,
                 new InputInstance().setTitle("Child Instance").setInstanceTypeId("12345").setSource("test").getJson(), 201);
         childInstanceId = responseOnPOSTChild.getString("id");
-        JsonObject responseOnPOSTParent = FakeInventoryStorage.post(
+        JsonObject responseOnPOSTParent = FakeFolioApis.post(
                 INSTANCE_STORAGE_PATH,
                 new InputInstance().setTitle("Parent Instance").setInstanceTypeId("12345").setSource("test").getJson(), 201);
         parentInstanceId = responseOnPOSTParent.getString("id");
     }
 
     protected void validatePostAndGetById(TestContext testContext) {
-        JsonObject responseOnPOST = FakeInventoryStorage.post(
+        JsonObject responseOnPOST = FakeFolioApis.post(
                 INSTANCE_RELATIONSHIP_STORAGE_PATH,
                 new InputInstanceRelationship().setSubInstanceId(childInstanceId).setSuperInstanceId(parentInstanceId).getJson());
         testContext.assertEquals(responseOnPOST.getString(SUB_INSTANCE_ID), childInstanceId);
-        JsonObject responseOnGET = FakeInventoryStorage.getRecordById(INSTANCE_RELATIONSHIP_STORAGE_PATH, responseOnPOST.getString("id"));
+        JsonObject responseOnGET = FakeFolioApis.getRecordById(INSTANCE_RELATIONSHIP_STORAGE_PATH, responseOnPOST.getString("id"));
         testContext.assertEquals(responseOnGET.getString(SUPER_INSTANCE_ID), parentInstanceId);
     }
 

--- a/src/test/java/org/folio/inventoryupdate/test/StorageValidatorInstances.java
+++ b/src/test/java/org/folio/inventoryupdate/test/StorageValidatorInstances.java
@@ -2,14 +2,14 @@ package org.folio.inventoryupdate.test;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
-import org.folio.inventoryupdate.test.fakestorage.FakeInventoryStorage;
+import org.folio.inventoryupdate.test.fakestorage.FakeFolioApis;
 import org.folio.inventoryupdate.test.fakestorage.RecordStorage;
 import org.folio.inventoryupdate.test.fakestorage.entitites.InputHoldingsRecord;
 import org.folio.inventoryupdate.test.fakestorage.entitites.InputInstance;
 import org.folio.inventoryupdate.test.fakestorage.entitites.InputInstanceRelationship;
 import org.folio.inventoryupdate.test.fakestorage.entitites.InputInstanceTitleSuccession;
 
-import static org.folio.inventoryupdate.test.fakestorage.FakeInventoryStorage.*;
+import static org.folio.inventoryupdate.test.fakestorage.FakeFolioApis.*;
 
 
 /**
@@ -26,33 +26,33 @@ public class StorageValidatorInstances  {
     validateCanDeleteInstanceById(testContext);
     cannotDeleteInstanceWithHoldings(testContext);
     cannotDeleteInstanceWithInstanceRelations(testContext);
-    // cannotDeleteInstanceWithTitleSuccession(testContext);
+    cannotDeleteInstanceWithTitleSuccession(testContext);
   }
 
   protected void validatePostAndGetById(TestContext testContext) {
-    JsonObject responseOnPOST = FakeInventoryStorage.post(
+    JsonObject responseOnPOST = FakeFolioApis.post(
             INSTANCE_STORAGE_PATH,
             new InputInstance().setTitle("New InputInstance").setInstanceTypeId("12345").setHrid("999999999").setSource("test").getJson());
     testContext.assertEquals(responseOnPOST.getString("title"), "New InputInstance");
-    JsonObject responseOnGET = FakeInventoryStorage.getRecordById(INSTANCE_STORAGE_PATH, responseOnPOST.getString("id"));
+    JsonObject responseOnGET = FakeFolioApis.getRecordById(INSTANCE_STORAGE_PATH, responseOnPOST.getString("id"));
     testContext.assertEquals(responseOnGET.getString("title"), "New InputInstance");
   }
 
   protected void validateGetByQueryAndPut(TestContext testContext) {
-    JsonObject responseJson = FakeInventoryStorage.getRecordsByQuery(
+    JsonObject responseJson = FakeFolioApis.getRecordsByQuery(
             INSTANCE_STORAGE_PATH,
             "query="+ RecordStorage.encode("title==\"New InputInstance\""));
     testContext.assertEquals(
             responseJson.getInteger("totalRecords"), 1,"Number of " + RESULT_SET_INSTANCES + " expected: 1" );
     JsonObject existingRecord = responseJson.getJsonArray(RESULT_SET_INSTANCES).getJsonObject(0);
     existingRecord.put("instanceTypeId", "456");
-    FakeInventoryStorage.put(INSTANCE_STORAGE_PATH, existingRecord);
-    JsonObject record = FakeInventoryStorage.getRecordById(INSTANCE_STORAGE_PATH, existingRecord.getString("id"));
+    FakeFolioApis.put(INSTANCE_STORAGE_PATH, existingRecord);
+    JsonObject record = FakeFolioApis.getRecordById(INSTANCE_STORAGE_PATH, existingRecord.getString("id"));
     testContext.assertEquals(record.getString("instanceTypeId"), "456");
   }
 
   protected void validateGetByIdList(TestContext testContext) {
-    JsonObject responseJson = FakeInventoryStorage.getRecordsByQuery(
+    JsonObject responseJson = FakeFolioApis.getRecordsByQuery(
             INSTANCE_STORAGE_PATH,
             "query="+ RecordStorage.encode("(hrid==(\"10\" OR \"999999999\")"));
     testContext.assertEquals(
@@ -60,56 +60,56 @@ public class StorageValidatorInstances  {
   }
 
   protected void validateCanDeleteInstanceById (TestContext testContext) {
-    JsonObject responseOnPOST = FakeInventoryStorage.post(
+    JsonObject responseOnPOST = FakeFolioApis.post(
             INSTANCE_STORAGE_PATH,
             new InputInstance().setTitle("InputInstance to delete").setInstanceTypeId("12345").setSource("test").getJson());
     testContext.assertEquals(responseOnPOST.getString("title"), "InputInstance to delete");
-    FakeInventoryStorage.delete(INSTANCE_STORAGE_PATH, responseOnPOST.getString("id"),200);
+    FakeFolioApis.delete(INSTANCE_STORAGE_PATH, responseOnPOST.getString("id"),200);
   }
 
   protected void cannotDeleteInstanceWithHoldings (TestContext testContext) {
-    JsonObject responseOnPOST = FakeInventoryStorage.post(
+    JsonObject responseOnPOST = FakeFolioApis.post(
             INSTANCE_STORAGE_PATH,
             new InputInstance().setTitle("InputInstance with holdings").setInstanceTypeId("12345").setSource("test").getJson(), 201);
     String instanceId = responseOnPOST.getString("id");
-    JsonObject responseOnHoldingsPOST = FakeInventoryStorage.post(
+    JsonObject responseOnHoldingsPOST = FakeFolioApis.post(
             HOLDINGS_STORAGE_PATH,
             new InputHoldingsRecord().setCallNumber("Test holdings").setPermanentLocationId(InventoryUpdateTestSuite.LOCATION_ID_1).setInstanceId(instanceId).getJson(), 201);
-    FakeInventoryStorage.delete(INSTANCE_STORAGE_PATH, instanceId, 400);
+    FakeFolioApis.delete(INSTANCE_STORAGE_PATH, instanceId, 400);
   }
 
   protected void cannotDeleteInstanceWithInstanceRelations (TestContext testContext) {
-    JsonObject responseOnPOSTChild = FakeInventoryStorage.post(
+    JsonObject responseOnPOSTChild = FakeFolioApis.post(
             INSTANCE_STORAGE_PATH,
             new InputInstance().setTitle("InputInstance with parent").setInstanceTypeId("12345").setSource("test").getJson(), 201);
     String childId = responseOnPOSTChild.getString("id");
-    JsonObject responseOnPOSTParent = FakeInventoryStorage.post(
+    JsonObject responseOnPOSTParent = FakeFolioApis.post(
             INSTANCE_STORAGE_PATH,
             new InputInstance().setTitle("InputInstance with child").setInstanceTypeId("12345").setSource("test").getJson(), 201);
     String parentId = responseOnPOSTParent.getString("id");
-    JsonObject responseOnPOSTRelation = FakeInventoryStorage.post(
+    JsonObject responseOnPOSTRelation = FakeFolioApis.post(
             INSTANCE_RELATIONSHIP_STORAGE_PATH,
             new InputInstanceRelationship()
                     .setSubInstanceId(childId)
                     .setSuperInstanceId(parentId).getJson(), 201);
-    FakeInventoryStorage.delete(INSTANCE_STORAGE_PATH, parentId, 400);
+    FakeFolioApis.delete(INSTANCE_STORAGE_PATH, parentId, 400);
   }
 
   protected void cannotDeleteInstanceWithTitleSuccession (TestContext testContext) {
-    JsonObject responseOnPOSTSucceeding = FakeInventoryStorage.post(
+    JsonObject responseOnPOSTSucceeding = FakeFolioApis.post(
             INSTANCE_STORAGE_PATH,
             new InputInstance().setTitle("Succeeding title").setInstanceTypeId("12345").setSource("test").getJson(), 201);
     String succeedingId = responseOnPOSTSucceeding.getString("id");
-    JsonObject responseOnPOSTPreceding = FakeInventoryStorage.post(
+    JsonObject responseOnPOSTPreceding = FakeFolioApis.post(
             INSTANCE_STORAGE_PATH,
             new InputInstance().setTitle("Preceding title").setInstanceTypeId("12345").setSource("test").getJson(), 201);
     String precedingId = responseOnPOSTPreceding.getString("id");
-    JsonObject responseOnPOSTSuccession = FakeInventoryStorage.post(
+    JsonObject responseOnPOSTSuccession = FakeFolioApis.post(
             PRECEDING_SUCCEEDING_TITLE_STORAGE_PATH,
             new InputInstanceTitleSuccession()
                     .setSucceedingInstanceId(succeedingId)
                     .setPrecedingInstanceId(precedingId).getJson(), 201);
-    FakeInventoryStorage.delete(INSTANCE_STORAGE_PATH, precedingId , 400);
+    FakeFolioApis.delete(INSTANCE_STORAGE_PATH, precedingId , 400);
   }
 
 }

--- a/src/test/java/org/folio/inventoryupdate/test/StorageValidatorItems.java
+++ b/src/test/java/org/folio/inventoryupdate/test/StorageValidatorItems.java
@@ -2,7 +2,7 @@ package org.folio.inventoryupdate.test;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
-import org.folio.inventoryupdate.test.fakestorage.FakeInventoryStorage;
+import org.folio.inventoryupdate.test.fakestorage.FakeFolioApis;
 import org.folio.inventoryupdate.test.fakestorage.RecordStorage;
 import org.folio.inventoryupdate.test.fakestorage.entitites.InputHoldingsRecord;
 import org.folio.inventoryupdate.test.fakestorage.entitites.InputInstance;
@@ -10,7 +10,7 @@ import org.folio.inventoryupdate.test.fakestorage.entitites.InputItem;
 
 import static org.folio.inventoryupdate.test.InventoryUpdateTestSuite.MATERIAL_TYPE_TEXT;
 import static org.folio.inventoryupdate.test.InventoryUpdateTestSuite.STATUS_UNKNOWN;
-import static org.folio.inventoryupdate.test.fakestorage.FakeInventoryStorage.*;
+import static org.folio.inventoryupdate.test.fakestorage.FakeFolioApis.*;
 
 public class StorageValidatorItems {
 
@@ -24,61 +24,61 @@ public class StorageValidatorItems {
         validateCannotPostWithBadHoldingsRecordId(testContext);
     }
     protected void createInstanceAndHoldings(TestContext testContext) {
-        JsonObject responseOnInstancePOST = FakeInventoryStorage.post(
+        JsonObject responseOnInstancePOST = FakeFolioApis.post(
                 INSTANCE_STORAGE_PATH,
                 new InputInstance().setTitle("Instance for Item test").setInstanceTypeId("123").setSource("test").getJson());
         String existingInstanceId = responseOnInstancePOST.getString("id");
-        JsonObject responseOnHoldingsPOST = FakeInventoryStorage.post(
+        JsonObject responseOnHoldingsPOST = FakeFolioApis.post(
                 HOLDINGS_STORAGE_PATH,
                 new InputHoldingsRecord().setPermanentLocationId(InventoryUpdateTestSuite.LOCATION_ID_1).setCallNumber("CN-FOR-ITEM-TEST").setInstanceId(existingInstanceId).getJson());
         existingHoldingsRecordId = responseOnHoldingsPOST.getString("id");
     }
 
     protected void validatePostAndGetById(TestContext testContext) {
-        JsonObject responseOnPOST = FakeInventoryStorage.post(
+        JsonObject responseOnPOST = FakeFolioApis.post(
                 ITEM_STORAGE_PATH,
                 new InputItem().setHoldingsRecordId(existingHoldingsRecordId).setBarcode("bc-001")
                         .setStatus(STATUS_UNKNOWN)
                         .setMaterialTypeId(MATERIAL_TYPE_TEXT)
                         .getJson());
         testContext.assertEquals(responseOnPOST.getString("barcode"), "bc-001");
-        JsonObject responseOnGET = FakeInventoryStorage.getRecordById(ITEM_STORAGE_PATH, responseOnPOST.getString("id"));
+        JsonObject responseOnGET = FakeFolioApis.getRecordById(ITEM_STORAGE_PATH, responseOnPOST.getString("id"));
         testContext.assertEquals(responseOnGET.getString("barcode"), "bc-001");
     }
 
     protected void validateGetByQueryAndPut(TestContext testContext) {
-        JsonObject responseJson = FakeInventoryStorage.getRecordsByQuery(
+        JsonObject responseJson = FakeFolioApis.getRecordsByQuery(
                 ITEM_STORAGE_PATH,
                 "query="+ RecordStorage.encode("holdingsRecordId==\""+ existingHoldingsRecordId +"\""));
         testContext.assertEquals(
                 responseJson.getInteger("totalRecords"), 1,"Number of " + RESULT_SET_ITEMS + " expected: 1" );
         JsonObject existingRecord = responseJson.getJsonArray(RESULT_SET_ITEMS).getJsonObject(0);
         existingRecord.put("barcode", "bc-002");
-        FakeInventoryStorage.put(ITEM_STORAGE_PATH, existingRecord);
-        JsonObject record = FakeInventoryStorage.getRecordById(ITEM_STORAGE_PATH, existingRecord.getString("id"));
+        FakeFolioApis.put(ITEM_STORAGE_PATH, existingRecord);
+        JsonObject record = FakeFolioApis.getRecordById(ITEM_STORAGE_PATH, existingRecord.getString("id"));
         testContext.assertEquals(record.getString("barcode"), "bc-002");
     }
 
     protected void validateCanDeleteItemById (TestContext testContext) {
-        JsonObject responseOnPOST = FakeInventoryStorage.post(
+        JsonObject responseOnPOST = FakeFolioApis.post(
                 ITEM_STORAGE_PATH,
                 new InputItem()
                         .setStatus(STATUS_UNKNOWN)
                         .setMaterialTypeId(MATERIAL_TYPE_TEXT)
                         .setBarcode("TEST-BC").setHoldingsRecordId(existingHoldingsRecordId).getJson());
         testContext.assertEquals(responseOnPOST.getString("barcode"), "TEST-BC");
-        FakeInventoryStorage.delete(ITEM_STORAGE_PATH, responseOnPOST.getString("id"),200);
+        FakeFolioApis.delete(ITEM_STORAGE_PATH, responseOnPOST.getString("id"),200);
     }
 
     protected void validateCannotPostWithBadHoldingsRecordId (TestContext testContext) {
-        JsonObject responseOnPOST = FakeInventoryStorage.post(
+        JsonObject responseOnPOST = FakeFolioApis.post(
                 ITEM_STORAGE_PATH,
                 new InputItem()
                         .setStatus(STATUS_UNKNOWN)
                         .setMaterialTypeId(MATERIAL_TYPE_TEXT)
                         .setHoldingsRecordId("12345").setBarcode("bc-003").getJson(),
                 500);
-        JsonObject responseJson = FakeInventoryStorage.getRecordsByQuery(
+        JsonObject responseJson = FakeFolioApis.getRecordsByQuery(
                 ITEM_STORAGE_PATH,
                 "query="+ RecordStorage.encode("holdingsRecordId==\"12345\""));
         testContext.assertEquals(

--- a/src/test/java/org/folio/inventoryupdate/test/StorageValidatorLocations.java
+++ b/src/test/java/org/folio/inventoryupdate/test/StorageValidatorLocations.java
@@ -2,80 +2,23 @@ package org.folio.inventoryupdate.test;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
-import org.folio.inventoryupdate.test.fakestorage.FakeInventoryStorage;
+import org.folio.inventoryupdate.test.fakestorage.FakeFolioApis;
 import org.folio.inventoryupdate.test.fakestorage.entitites.InputLocation;
 
-import static org.folio.inventoryupdate.test.fakestorage.FakeInventoryStorage.*;
+import static org.folio.inventoryupdate.test.fakestorage.FakeFolioApis.*;
 
 public class StorageValidatorLocations {
     protected void validateStorage(TestContext testContext) {
 
         validatePostAndGetById(testContext);
-        //validateGetByQueryAndPut(testContext);
-        //validateCanDeleteInstanceById(testContext);
-        //cannotDeleteInstanceWithHoldings(testContext);
-        //cannotDeleteInstanceWithInstanceRelations(testContext);
-        // cannotDeleteInstanceWithTitleSuccession(testContext);
     }
 
     protected void validatePostAndGetById(TestContext testContext) {
-        JsonObject responseOnPOST = FakeInventoryStorage.post(
+        JsonObject responseOnPOST = FakeFolioApis.post(
                 LOCATION_STORAGE_PATH,
                 new InputLocation().setId("LOC3").setInstitutionId("INST3").setName("Test Location").getJson());
         testContext.assertEquals(responseOnPOST.getString("id"), "LOC3");
-        JsonObject responseOnGET = FakeInventoryStorage.getRecordById(LOCATION_STORAGE_PATH, responseOnPOST.getString("id"));
+        JsonObject responseOnGET = FakeFolioApis.getRecordById(LOCATION_STORAGE_PATH, responseOnPOST.getString("id"));
         testContext.assertEquals(responseOnGET.getString("institutionId"), "INST3");
     }
-/*
-    protected void validateGetByQueryAndPut(TestContext testContext) {
-        JsonObject responseJson = FakeInventoryStorage.getRecordsByQuery(
-                INSTANCE_STORAGE_PATH,
-                "query="+ RecordStorage.encode("title==\"New InputInstance\""));
-        testContext.assertEquals(
-                responseJson.getInteger("totalRecords"), 1,"Number of " + RESULT_SET_INSTANCES + " expected: 1" );
-        JsonObject existingRecord = responseJson.getJsonArray(RESULT_SET_INSTANCES).getJsonObject(0);
-        existingRecord.put("instanceTypeId", "456");
-        FakeInventoryStorage.put(INSTANCE_STORAGE_PATH, existingRecord);
-        JsonObject record = FakeInventoryStorage.getRecordById(INSTANCE_STORAGE_PATH, existingRecord.getString("id"));
-        testContext.assertEquals(record.getString("instanceTypeId"), "456");
-    }
-
-    protected void validateCanDeleteInstanceById (TestContext testContext) {
-        JsonObject responseOnPOST = FakeInventoryStorage.post(
-                INSTANCE_STORAGE_PATH,
-                new InputInstance().setTitle("InputInstance to delete").setInstanceTypeId("12345").getJson());
-        testContext.assertEquals(responseOnPOST.getString("title"), "InputInstance to delete");
-        FakeInventoryStorage.delete(INSTANCE_STORAGE_PATH, responseOnPOST.getString("id"),200);
-    }
-
-    protected void cannotDeleteInstanceWithHoldings (TestContext testContext) {
-        JsonObject responseOnPOST = FakeInventoryStorage.post(
-                INSTANCE_STORAGE_PATH,
-                new InputInstance().setTitle("InputInstance with holdings").setInstanceTypeId("12345").getJson(), 201);
-        String instanceId = responseOnPOST.getString("id");
-        JsonObject responseOnHoldingsPOST = FakeInventoryStorage.post(
-                HOLDINGS_STORAGE_PATH,
-                new InputHoldingsRecord().setCallNumber("Test holdings").setPermanentLocationId(InventoryUpdateTestSuite.LOCATION_ID).setInstanceId(instanceId).getJson(), 201);
-        FakeInventoryStorage.delete(INSTANCE_STORAGE_PATH, instanceId, 400);
-    }
-
-    protected void cannotDeleteInstanceWithInstanceRelations (TestContext testContext) {
-        JsonObject responseOnPOSTChild = FakeInventoryStorage.post(
-                INSTANCE_STORAGE_PATH,
-                new InputInstance().setTitle("InputInstance with parent").setInstanceTypeId("12345").getJson(), 201);
-        String childId = responseOnPOSTChild.getString("id");
-        JsonObject responseOnPOSTParent = FakeInventoryStorage.post(
-                INSTANCE_STORAGE_PATH,
-                new InputInstance().setTitle("InputInstance with child").setInstanceTypeId("12345").getJson(), 201);
-        String parentId = responseOnPOSTParent.getString("id");
-        JsonObject responseOnPOSTRelation = FakeInventoryStorage.post(
-                INSTANCE_RELATIONSHIP_STORAGE_PATH,
-                new InputInstanceRelationship()
-                        .setSubInstanceId(childId)
-                        .setSuperInstanceId(parentId).getJson(), 201);
-        FakeInventoryStorage.delete(INSTANCE_STORAGE_PATH, parentId, 400);
-    }
-
- */
-
 }

--- a/src/test/java/org/folio/inventoryupdate/test/StorageValidatorPoLines.java
+++ b/src/test/java/org/folio/inventoryupdate/test/StorageValidatorPoLines.java
@@ -1,0 +1,25 @@
+package org.folio.inventoryupdate.test;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.TestContext;
+import org.folio.inventoryupdate.test.fakestorage.FakeFolioApis;
+
+import static org.folio.inventoryupdate.test.fakestorage.FakeFolioApis.*;
+
+public class StorageValidatorPoLines {
+  protected void validateStorage(TestContext testContext) {
+    validatePostAndGetById(testContext);
+  }
+
+  protected void validatePostAndGetById(TestContext testContext) {
+    JsonObject responseOnPOST = FakeFolioApis.post(
+        ORDER_LINES_STORAGE_PATH,
+        new JsonObject("{\"purchaseOrderId\": \"3b198b70-cf8e-4075-9e93-ebf2c76e60c2\", " +
+            "\"instanceId\": \"ff8702a1-c562-48f0-a3fe-00421ce3c6d3\", \"orderFormat\": \"Other\", \"source\": \"User\", \"titleOrPackage\": \"New InputInstance\" }"));
+    testContext.assertEquals(responseOnPOST.getString("titleOrPackage"), "New InputInstance");
+    JsonObject responseOnGET = FakeFolioApis.getRecordById(ORDER_LINES_STORAGE_PATH, responseOnPOST.getString("id"));
+    testContext.assertEquals(responseOnGET.getString("titleOrPackage"), "New InputInstance");
+  }
+
+
+}

--- a/src/test/java/org/folio/inventoryupdate/test/StorageValidatorPrecedingSucceeding.java
+++ b/src/test/java/org/folio/inventoryupdate/test/StorageValidatorPrecedingSucceeding.java
@@ -2,11 +2,11 @@ package org.folio.inventoryupdate.test;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
-import org.folio.inventoryupdate.test.fakestorage.FakeInventoryStorage;
+import org.folio.inventoryupdate.test.fakestorage.FakeFolioApis;
 import org.folio.inventoryupdate.test.fakestorage.entitites.InputInstance;
 import org.folio.inventoryupdate.test.fakestorage.entitites.InputInstanceTitleSuccession;
 import static org.folio.inventoryupdate.test.fakestorage.entitites.InputInstanceTitleSuccession.*;
-import static org.folio.inventoryupdate.test.fakestorage.FakeInventoryStorage.*;
+import static org.folio.inventoryupdate.test.fakestorage.FakeFolioApis.*;
 
 public class StorageValidatorPrecedingSucceeding  {
     private String succeedingInstanceId;
@@ -17,22 +17,22 @@ public class StorageValidatorPrecedingSucceeding  {
     }
 
     protected void createTwoTitles (TestContext testContext) {
-        JsonObject responseOnPOSTSucceeding = FakeInventoryStorage.post(
+        JsonObject responseOnPOSTSucceeding = FakeFolioApis.post(
                 INSTANCE_STORAGE_PATH,
                 new InputInstance().setTitle("Succeeding title").setInstanceTypeId("12345").setSource("test").getJson(), 201);
         succeedingInstanceId = responseOnPOSTSucceeding.getString("id");
-        JsonObject responseOnPOSTPreceding = FakeInventoryStorage.post(
+        JsonObject responseOnPOSTPreceding = FakeFolioApis.post(
                 INSTANCE_STORAGE_PATH,
                 new InputInstance().setTitle("Preceding title").setInstanceTypeId("12345").setSource("test").getJson(), 201);
         precedingInstanceId = responseOnPOSTPreceding.getString("id");
     }
 
     protected void validatePostAndGetById(TestContext testContext) {
-        JsonObject responseOnPOST = FakeInventoryStorage.post(
+        JsonObject responseOnPOST = FakeFolioApis.post(
                 PRECEDING_SUCCEEDING_TITLE_STORAGE_PATH,
                 new InputInstanceTitleSuccession().setSucceedingInstanceId(succeedingInstanceId).setPrecedingInstanceId(precedingInstanceId).getJson());
         testContext.assertEquals(responseOnPOST.getString(SUCCEEDING_INSTANCE_ID), succeedingInstanceId);
-        JsonObject responseOnGET = FakeInventoryStorage.getRecordById(PRECEDING_SUCCEEDING_TITLE_STORAGE_PATH, responseOnPOST.getString("id"));
+        JsonObject responseOnGET = FakeFolioApis.getRecordById(PRECEDING_SUCCEEDING_TITLE_STORAGE_PATH, responseOnPOST.getString("id"));
         testContext.assertEquals(responseOnGET.getString(SUCCEEDING_INSTANCE_ID), succeedingInstanceId);
     }
 

--- a/src/test/java/org/folio/inventoryupdate/test/StorageValidatorQueries.java
+++ b/src/test/java/org/folio/inventoryupdate/test/StorageValidatorQueries.java
@@ -3,12 +3,12 @@ package org.folio.inventoryupdate.test;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
-import org.folio.inventoryupdate.test.fakestorage.FakeInventoryStorage;
+import org.folio.inventoryupdate.test.fakestorage.FakeFolioApis;
 import org.folio.inventoryupdate.test.fakestorage.RecordStorage;
 import org.folio.inventoryupdate.test.fakestorage.entitites.InputInstance;
 
-import static org.folio.inventoryupdate.test.fakestorage.FakeInventoryStorage.INSTANCE_STORAGE_PATH;
-import static org.folio.inventoryupdate.test.fakestorage.FakeInventoryStorage.RESULT_SET_INSTANCES;
+import static org.folio.inventoryupdate.test.fakestorage.FakeFolioApis.INSTANCE_STORAGE_PATH;
+import static org.folio.inventoryupdate.test.fakestorage.FakeFolioApis.RESULT_SET_INSTANCES;
 
 public class StorageValidatorQueries
 {
@@ -20,15 +20,15 @@ public class StorageValidatorQueries
     }
 
     protected void validateMatchKeyQuery (TestContext testContext) {
-        FakeInventoryStorage.post(
+        FakeFolioApis.post(
                 INSTANCE_STORAGE_PATH,
                 new InputInstance().setTitle("New Input Instance").setInstanceTypeId("1111").setMatchKeyAsString("new_input_instance").setSource("test").getJson());
 
-        FakeInventoryStorage.post(
+        FakeFolioApis.post(
                 INSTANCE_STORAGE_PATH,
                 new InputInstance().setTitle("Another Input Instance").setInstanceTypeId("2222").setMatchKeyAsString("another_input_instance").setSource("test").getJson());
 
-        JsonObject responseOnQueryWithMatch = FakeInventoryStorage.getRecordsByQuery(INSTANCE_STORAGE_PATH,
+        JsonObject responseOnQueryWithMatch = FakeFolioApis.getRecordsByQuery(INSTANCE_STORAGE_PATH,
                 "query="+RecordStorage.encode("matchKey==\"another_input_instance\""));
 
         testContext.assertEquals(
@@ -36,7 +36,7 @@ public class StorageValidatorQueries
         JsonObject foundRecord = responseOnQueryWithMatch.getJsonArray(RESULT_SET_INSTANCES).getJsonObject(0);
         testContext.assertEquals(foundRecord.getString( "title" ), "Another Input Instance");
 
-        JsonObject responseOnQueryWithOutMatch = FakeInventoryStorage.getRecordsByQuery(INSTANCE_STORAGE_PATH,
+        JsonObject responseOnQueryWithOutMatch = FakeFolioApis.getRecordsByQuery(INSTANCE_STORAGE_PATH,
                 "query="+RecordStorage.encode("matchKey==\"a_third_input_instance\""));
         testContext.assertEquals(
                 responseOnQueryWithOutMatch.getInteger("totalRecords"), 0,"Number of " + RESULT_SET_INSTANCES + " expected: 0" );
@@ -44,7 +44,7 @@ public class StorageValidatorQueries
 
     protected void validateOrQuery (TestContext testContext) {
 
-        JsonObject responseOnOrQuery = FakeInventoryStorage.getRecordsByQuery(INSTANCE_STORAGE_PATH,
+        JsonObject responseOnOrQuery = FakeFolioApis.getRecordsByQuery(INSTANCE_STORAGE_PATH,
                 "query="+RecordStorage.encode("matchKey==\"another_input_instance\" or instanceTypeId==\"1111\""));
 
         testContext.assertEquals(
@@ -52,14 +52,14 @@ public class StorageValidatorQueries
     }
 
     protected void validateIdentifierQuery (TestContext testContext) {
-        FakeInventoryStorage.post(
+        FakeFolioApis.post(
                 INSTANCE_STORAGE_PATH,
                 new InputInstance().setTitle("Shared Input Instance with identifier")
                         .setInstanceTypeId("12345")
                         .setSource("test")
                         .setIdentifiers(new JsonArray().add(new JsonObject().put("identifierTypeId","4321").put("value","888888"))).getJson());
 
-        JsonObject responseOnIdentifierQuery = FakeInventoryStorage.getRecordsByQuery( INSTANCE_STORAGE_PATH,
+        JsonObject responseOnIdentifierQuery = FakeFolioApis.getRecordsByQuery( INSTANCE_STORAGE_PATH,
                 "query="+RecordStorage.encode("(identifiers =/@value/@identifierTypeId=\"4321\" \"888888\")"));
 
         testContext.assertEquals(
@@ -67,13 +67,13 @@ public class StorageValidatorQueries
     }
 
     protected void validateEqualityAndNotEqualityQuery (TestContext testContext) {
-        JsonObject responseOnNotQuery1 = FakeInventoryStorage.getRecordsByQuery(INSTANCE_STORAGE_PATH,
+        JsonObject responseOnNotQuery1 = FakeFolioApis.getRecordsByQuery(INSTANCE_STORAGE_PATH,
                 "query="+RecordStorage.encode("(identifiers =/@value/@identifierTypeId=\"4321\" \"888888\" not instanceTypeId==\"12345\")"));
 
         testContext.assertEquals(
                 responseOnNotQuery1.getInteger("totalRecords"), 0,"Number of " + RESULT_SET_INSTANCES + " expected: 0" );
 
-        JsonObject responseOnNotQuery2 = FakeInventoryStorage.getRecordsByQuery(INSTANCE_STORAGE_PATH,
+        JsonObject responseOnNotQuery2 = FakeFolioApis.getRecordsByQuery(INSTANCE_STORAGE_PATH,
                 "query="+RecordStorage.encode("(identifiers =/@value/@identifierTypeId=\"4321\" \"888888\" not instanceTypeId==\"rexx\")"));
 
         testContext.assertEquals(

--- a/src/test/java/org/folio/inventoryupdate/test/fakestorage/DeleteProcessingInstructions.java
+++ b/src/test/java/org/folio/inventoryupdate/test/fakestorage/DeleteProcessingInstructions.java
@@ -1,7 +1,7 @@
 package org.folio.inventoryupdate.test.fakestorage;
 
 import io.vertx.core.json.JsonObject;
-import org.folio.inventoryupdate.ProcessingInstructionsDeletion;
+import org.folio.inventoryupdate.instructions.ProcessingInstructionsDeletion;
 
 
 public class DeleteProcessingInstructions {
@@ -42,7 +42,7 @@ public class DeleteProcessingInstructions {
     return processingInstructions;
   }
 
-  public DeleteProcessingInstructions setItemRecordRetentionCriterion(String fieldName, String pattern) {
+  public DeleteProcessingInstructions setItemBlockDeletionCriterion(String fieldName, String pattern) {
     if (!getItemInstructions().containsKey(BLOCK_DELETION_KEY)) {
       getItemInstructions().put(BLOCK_DELETION_KEY, new JsonObject());
     }
@@ -52,7 +52,7 @@ public class DeleteProcessingInstructions {
     return this;
   }
 
-  public DeleteProcessingInstructions setHoldingsRecordRetentionCriterion(String fieldName, String pattern) {
+  public DeleteProcessingInstructions setHoldingsBlockDeletionCriterion(String fieldName, String pattern) {
     if (!getHoldingsInstructions().containsKey(BLOCK_DELETION_KEY)) {
       getHoldingsInstructions().put(BLOCK_DELETION_KEY, new JsonObject());
     }

--- a/src/test/java/org/folio/inventoryupdate/test/fakestorage/FakeFolioApis.java
+++ b/src/test/java/org/folio/inventoryupdate/test/fakestorage/FakeFolioApis.java
@@ -9,8 +9,8 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.handler.BodyHandler;
 
-public class FakeInventoryStorage {
-    public final static int PORT_INVENTORY_STORAGE = 9030;
+public class FakeFolioApis {
+    public final static int PORT_OKAPI = 9030;
     public final static String INSTANCE_STORAGE_PATH = "/instance-storage/instances";
     public final static String INSTANCE_SET_PATH = "/inventory-view/instance-set";
     public static final String INSTANCE_RELATIONSHIP_STORAGE_PATH = "/instance-storage/instance-relationships";
@@ -22,6 +22,8 @@ public class FakeInventoryStorage {
     public static final String INSTANCE_STORAGE_BATCH_PATH = "/instance-storage/batch/synchronous";
     public static final String HOLDINGS_STORAGE_BATCH_PATH = "/holdings-storage/batch/synchronous";
     public static final String ITEM_STORAGE_BATCH_PATH = "/item-storage/batch/synchronous";
+
+    public static final String ORDER_LINES_STORAGE_PATH = "/orders-storage/po-lines";
 
     public static final String RESULT_SET_INSTANCES = "instances";
     public static final String RESULT_SET_HOLDINGS_RECORDS = "holdingsRecords";
@@ -35,7 +37,9 @@ public class FakeInventoryStorage {
     public InstanceRelationshipStorage instanceRelationshipStorage = new InstanceRelationshipStorage();
     public PrecedingSucceedingStorage precedingSucceedingStorage = new PrecedingSucceedingStorage();
 
-    public FakeInventoryStorage(Vertx vertx, TestContext testContext) {
+    public OrdersStorage ordersStorage = new OrdersStorage();
+
+    public FakeFolioApis(Vertx vertx, TestContext testContext) {
         locationStorage.attachToFakeStorage(this);
         instanceStorage.attachToFakeStorage(this);
         instanceSetview.attachToFakeStorage(this);
@@ -43,6 +47,7 @@ public class FakeInventoryStorage {
         itemStorage.attachToFakeStorage(this);
         instanceRelationshipStorage.attachToFakeStorage(this);
         precedingSucceedingStorage.attachToFakeStorage(this);
+        ordersStorage.attachToFakeStorage(this);
 
         Router router = Router.router(vertx);
         router.get(LOCATION_STORAGE_PATH).handler(locationStorage::getRecords);
@@ -58,6 +63,8 @@ public class FakeInventoryStorage {
         router.get(INSTANCE_RELATIONSHIP_STORAGE_PATH + "/:id").handler(instanceRelationshipStorage::getRecordById);
         router.get(PRECEDING_SUCCEEDING_TITLE_STORAGE_PATH).handler(precedingSucceedingStorage::getRecords);
         router.get(PRECEDING_SUCCEEDING_TITLE_STORAGE_PATH + "/:id").handler(precedingSucceedingStorage::getRecordById);
+        router.get(ORDER_LINES_STORAGE_PATH).handler(ordersStorage::getRecords);
+        router.get(ORDER_LINES_STORAGE_PATH + "/:id").handler(ordersStorage::getRecordById);
         router.post("/*").handler(BodyHandler.create());
         router.post(LOCATION_STORAGE_PATH).handler(locationStorage::createRecord);
         router.post(INSTANCE_STORAGE_PATH).handler(instanceStorage::createRecord);
@@ -68,6 +75,7 @@ public class FakeInventoryStorage {
         router.post(INSTANCE_RELATIONSHIP_STORAGE_PATH).handler(instanceRelationshipStorage::createRecord);
         router.post(PRECEDING_SUCCEEDING_TITLE_STORAGE_PATH).handler(precedingSucceedingStorage::createRecord);
         router.post(INSTANCE_STORAGE_BATCH_PATH).handler(instanceStorage::upsertRecords);
+        router.post(ORDER_LINES_STORAGE_PATH).handler(ordersStorage::createRecord);
         router.put("/*").handler(BodyHandler.create());
         router.put(LOCATION_STORAGE_PATH + "/:id").handler(locationStorage::updateRecord);
         router.put(INSTANCE_STORAGE_PATH + "/:id").handler(instanceStorage::updateRecord);
@@ -84,9 +92,9 @@ public class FakeInventoryStorage {
         HttpServerOptions so = new HttpServerOptions().setHandle100ContinueAutomatically(true);
         vertx.createHttpServer(so)
                 .requestHandler(router)
-                .listen(PORT_INVENTORY_STORAGE)
+                .listen(PORT_OKAPI)
                 .onComplete(testContext.asyncAssertSuccess());
-        RestAssured.port = FakeInventoryStorage.PORT_INVENTORY_STORAGE;
+        RestAssured.port = FakeFolioApis.PORT_OKAPI;
     }
 
     public static JsonObject getRecordsByQuery(String storagePath, String query) {

--- a/src/test/java/org/folio/inventoryupdate/test/fakestorage/FakeFolioApis.java
+++ b/src/test/java/org/folio/inventoryupdate/test/fakestorage/FakeFolioApis.java
@@ -115,7 +115,8 @@ public class FakeFolioApis {
     }
 
     public static JsonObject getRecordById(String storagePath, String id, int expectedResponseCode) {
-        Response response = RestAssured.given()
+      RestAssured.port = FakeFolioApis.PORT_OKAPI;
+      Response response = RestAssured.given()
                 .get(storagePath + "/" + id)
                 .then()
                 .log().ifValidationFails()
@@ -128,7 +129,8 @@ public class FakeFolioApis {
     }
 
     public static JsonObject post(String storagePath, JsonObject recordToPOST, int expectedResponseCode) {
-        Response response = RestAssured.given()
+      RestAssured.port = FakeFolioApis.PORT_OKAPI;
+      Response response = RestAssured.given()
                 .body(recordToPOST.toString())
                 .post(storagePath)
                 .then()

--- a/src/test/java/org/folio/inventoryupdate/test/fakestorage/InputProcessingInstructions.java
+++ b/src/test/java/org/folio/inventoryupdate/test/fakestorage/InputProcessingInstructions.java
@@ -152,6 +152,28 @@ public class InputProcessingInstructions {
     return this;
   }
 
+  public InputProcessingInstructions setItemStatisticalCoding(JsonArray codings) {
+    getItemInstructions().put("statisticalCoding", codings);
+    return this;
+  }
+
+  public InputProcessingInstructions setHoldingsRecordRetentionCriterion(String fieldName, String pattern) {
+    if (!getHoldingsRecordInstructions().containsKey(ProcessingInstructionsUpsert.RECORD_RETENTION_KEY)) {
+      getHoldingsRecordInstructions().put(ProcessingInstructionsUpsert.RECORD_RETENTION_KEY, new JsonObject());
+    }
+    getHoldingsRecordInstructions().getJsonObject(ProcessingInstructionsUpsert.RECORD_RETENTION_KEY)
+        .put(ProcessingInstructionsUpsert.RECORD_RETENTION_CRITERION_FIELD, fieldName)
+        .put(ProcessingInstructionsUpsert.RECORD_RETENTION_CRITERION_PATTERN, pattern);
+    return this;
+  }
+
+  public InputProcessingInstructions setHoldingsRecordStatisticalCoding(JsonArray codings) {
+    getHoldingsRecordInstructions().put("statisticalCoding", codings);
+    return this;
+
+  }
+
+
   public JsonObject getJson() {
     return processingInstructions;
   }

--- a/src/test/java/org/folio/inventoryupdate/test/fakestorage/InputProcessingInstructions.java
+++ b/src/test/java/org/folio/inventoryupdate/test/fakestorage/InputProcessingInstructions.java
@@ -2,7 +2,7 @@ package org.folio.inventoryupdate.test.fakestorage;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import org.folio.inventoryupdate.ProcessingInstructionsUpsert;
+import org.folio.inventoryupdate.instructions.ProcessingInstructionsUpsert;
 
 public class InputProcessingInstructions {
   JsonObject processingInstructions = new JsonObject();

--- a/src/test/java/org/folio/inventoryupdate/test/fakestorage/OrdersStorage.java
+++ b/src/test/java/org/folio/inventoryupdate/test/fakestorage/OrdersStorage.java
@@ -1,0 +1,18 @@
+package org.folio.inventoryupdate.test.fakestorage;
+
+public class OrdersStorage extends RecordStorage {
+  @Override
+  protected String getResultSetName() {
+    return PO_LINES;
+  }
+
+  @Override
+  protected void declareDependencies() {
+
+  }
+
+  @Override
+  protected void declareMandatoryProperties() {
+
+  }
+}

--- a/src/test/java/org/folio/inventoryupdate/test/fakestorage/RecordStorage.java
+++ b/src/test/java/org/folio/inventoryupdate/test/fakestorage/RecordStorage.java
@@ -22,6 +22,7 @@ public abstract class RecordStorage {
     public static final String INSTANCE_RELATIONSHIPS = "instanceRelationships";
     public static final String PRECEDING_SUCCEEDING_TITLES = "precedingSucceedingTitles";
     public static final String LOCATIONS = "locations";
+    public static final String PO_LINES = "poLines";
 
     public final String STORAGE_NAME = getClass().getSimpleName();
     public boolean failOnDelete = false;
@@ -34,12 +35,12 @@ public abstract class RecordStorage {
     List<String> mandatoryProperties = new ArrayList<>();
     List<String> uniqueProperties = new ArrayList<>();
 
-    protected FakeInventoryStorage fakeStorage;
+    protected FakeFolioApis fakeStorage;
 
     protected final Map<String, InventoryRecord> records = new HashMap<>();
     protected final Logger logger = LoggerFactory.getLogger("fake-inventory-storage");
 
-    public void attachToFakeStorage(FakeInventoryStorage fakeStorage) {
+    public void attachToFakeStorage(FakeFolioApis fakeStorage) {
         this.fakeStorage = fakeStorage;
         declareDependencies();
         declareMandatoryProperties();
@@ -214,7 +215,7 @@ public abstract class RecordStorage {
 
     protected abstract void declareMandatoryProperties ();
 
-    protected void declareUniqueProperties () {};
+    protected void declareUniqueProperties () {}
     // API REQUEST HANDLERS
 
     /**


### PR DESCRIPTION
### Purpose
Protect instances (with their holdings and items) from deletion when there are existing orders in acquisitions referencing an instance.

### Approach
For now it's implemented by skipping the delete process when a lookup in mod-orders-storage discovers that a reference exists. This skipping is silent apart from being reported by MIU in the SKIPPED counts in the response. 