### PR TITLE
MODINVUP-101 holdings-storage dependencies

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -218,7 +218,7 @@
       "version": "9.0 10.0"
     },
     { "id": "holdings-storage",
-      "version":  "4.1 5.0 6.0"
+      "version":  "5.0 6.0 7.0"
     },
     {
       "id": "item-storage",
@@ -230,7 +230,7 @@
     },
     {
       "id": "holdings-storage-batch-sync",
-      "version": "1.1"
+      "version": "1.1 2.0"
     },
     {
       "id": "item-storage-batch-sync",

--- a/ramls/holdings-record.json
+++ b/ramls/holdings-record.json
@@ -12,6 +12,11 @@
       "type": "string",
       "description": "the human readable ID, also called eye readable ID. A system-assigned sequential ID which maps to the Instance ID"
     },
+    "sourceId": {
+      "description": "(A reference to) the source of a holdings record",
+      "type": "string",
+      "$ref": "raml-util/schemas/uuid.schema"
+    },
     "holdingsTypeId": {
       "type": "string",
       "description": "unique ID for the type of this holdings record, a UUID",
@@ -260,6 +265,7 @@
   },
   "additionalProperties": false,
   "required": [
+    "sourceId",
     "instanceId",
     "permanentLocationId"
   ]


### PR DESCRIPTION
   holdingsRecord.sourceId has become required in storage (was always provided in CBS-2-FOLIO)