### PR TITLE
MODINVUP-114 - Upgrade API versions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 ## 3.4.2
 
-* Provides `holdings-storage 8.0`
+* Requires `holdings-storage 5.0 6.0 7.0 8.0`
 
 ## 3.4.1 2024-08-06
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,6 @@
 ## 3.4.2
 
-* Provides `instance-storage 11.0`
 * Provides `holdings-storage 8.0`
-* Provides `instance-storage-batch-sync 3.0`
 
 ## 3.4.1 2024-08-06
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+## 3.4.2
+
+* Provides `instance-storage 11.0`
+* Provides `holdings-storage 8.0`
+* Provides `instance-storage-batch-sync 3.0`
+
 ## 3.4.1 2024-08-06
 
 * [MODINVUP-106](https://issues.folio.org/browse/MODINVUP-106) Works around inventory storage deadlock when updating instance records plus holdings records

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -308,7 +308,7 @@
       "version": "9.0 10.0 11.0"
     },
     { "id": "holdings-storage",
-      "version":  "5.0 6.0 7.0"
+      "version":  "5.0 6.0 7.0 8.0"
     },
     {
       "id": "item-storage",


### PR DESCRIPTION
[MODINVUP-114](https://folio-org.atlassian.net/browse/MODINVUP-114)
Upgrade the API version in the ModuleDescriptor-template.json:

-`holdings-storage 8.0`
