### PR TITLE
MODINVUP-7 logging: put miu request id on sub-requests

### DIFF
--- a/src/main/java/org/folio/inventoryupdate/InventoryStorage.java
+++ b/src/main/java/org/folio/inventoryupdate/InventoryStorage.java
@@ -60,6 +60,10 @@ public class InventoryStorage {
   public static final String ITEMS = "items";
   public static final String LOCATIONS = "locations";
 
+  private static final String X_OKAPI_TOKEN = "X-Okapi-Token";
+  private static final String X_OKAPI_TENANT = "X-Okapi-Tenant";
+  private static final String X_OKAPI_REQUEST_ID = "X-Okapi-Request-Id";
+
   public static Future<JsonObject> postInventoryRecord (OkapiClient okapiClient, InventoryRecord inventoryRecord) {
     Promise<JsonObject> promise = Promise.promise();
     okapiClient.post(getApi(inventoryRecord.entityType()), inventoryRecord.asJsonString(), postResult -> {
@@ -427,9 +431,9 @@ public class InventoryStorage {
     OkapiClient client = new OkapiClient(WebClientFactory.getWebClient(ctx.vertx()), ctx);
     Map<String, String> headers = new HashMap<>();
     headers.put("Content-type", "application/json");
-    if (ctx.request().getHeader("X-Okapi-Tenant") != null) headers.put("X-Okapi-Tenant", ctx.request().getHeader("X-Okapi-Tenant"));
-    if (ctx.request().getHeader("X-Okapi-Token") != null) headers.put("X-Okapi-Token", ctx.request().getHeader("X-Okapi-Token"));
-    if (ctx.request().getHeader("X-Okapi-Request-Id") != null) headers.put("X-Okapi-Request-Id", ctx.request().getHeader("X-Okapi-Request-Id"));
+    if (ctx.request().getHeader(X_OKAPI_TENANT) != null) headers.put(X_OKAPI_TENANT, ctx.request().getHeader(X_OKAPI_TENANT));
+    if (ctx.request().getHeader(X_OKAPI_TOKEN) != null) headers.put(X_OKAPI_TOKEN, ctx.request().getHeader(X_OKAPI_TOKEN));
+    if (ctx.request().getHeader(X_OKAPI_REQUEST_ID) != null) headers.put(X_OKAPI_REQUEST_ID, ctx.request().getHeader(X_OKAPI_REQUEST_ID));
     headers.put("Accept", "application/json, text/plain");
     client.setHeaders(headers);
     return client;

--- a/src/main/java/org/folio/inventoryupdate/InventoryStorage.java
+++ b/src/main/java/org/folio/inventoryupdate/InventoryStorage.java
@@ -429,6 +429,7 @@ public class InventoryStorage {
     headers.put("Content-type", "application/json");
     if (ctx.request().getHeader("X-Okapi-Tenant") != null) headers.put("X-Okapi-Tenant", ctx.request().getHeader("X-Okapi-Tenant"));
     if (ctx.request().getHeader("X-Okapi-Token") != null) headers.put("X-Okapi-Token", ctx.request().getHeader("X-Okapi-Token"));
+    if (ctx.request().getHeader("X-Okapi-Request-Id") != null) headers.put("X-Okapi-Request-Id", ctx.request().getHeader("X-Okapi-Request-Id"));
     headers.put("Accept", "application/json, text/plain");
     client.setHeaders(headers);
     return client;


### PR DESCRIPTION
 -  In order to track stream of Inventory Storage requests spawned by one miu request