### PR TITLE
[MODORDSTOR-448] Updated po-lines interface version

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -342,7 +342,7 @@
   "optional": [
     {
       "id": "orders-storage.po-lines",
-      "version": "12.0"
+      "version": "13.0"
     }
   ],
   "permissionSets": [


### PR DESCRIPTION
## Purpose
[MODORDSTOR-448](https://folio-org.atlassian.net/browse/MODORDSTOR-448) - Make user limit as string field & apply migration

## Approach
- Updated `po-lines` interface version

## Related PRs
See [acq-models](https://github.com/folio-org/acq-models/pull/519) or [mod-orders-storage](https://github.com/folio-org/mod-orders-storage/pull/476) PRs (there are lots).