### PR TITLE
MODINVUP-189 fix premature interface dependency

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -601,7 +601,7 @@
   "optional": [
     {
       "id": "orders-storage.po-lines",
-      "version": "13.0"
+      "version": "12.4 13.0"
     },
     {
       "id": "settings",


### PR DESCRIPTION
 - declare optional dependency on v12.4 or v13.0 of orders-storag/po-lines