### PR TITLE
MODINVUP-192 change permission names, mod-settings

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -854,7 +854,7 @@
       "permissionName": "mod-settings.global.write.mod-inventory-update.manage",
       "displayName": "Settings (import admin): write import admin settings",
       "visible": false,
-      "replaces": ["mod-settings.global.write.mod-inventory.update"]
+      "replaces": ["mod-settings.global.write.mod-inventory-update"]
     },
     {
       "permissionName": "modperms.inventory-update.import",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -538,7 +538,7 @@
           "modulePermissions": [
             "configuration.entries.collection.get",
             "mod-settings.entries.collection.get",
-            "mod-settings.global.read.mod-inventory-update"
+            "mod-settings.global.read.mod-inventory-update.manage"
           ],
           "schedule": {
             "cron": "0 2 * * *",
@@ -845,12 +845,12 @@
       ]
     },
     {
-      "permissionName": "mod-settings.global.read.mod-inventory-update",
+      "permissionName": "mod-settings.global.read.mod-inventory-update.manage",
       "displayName": "Settings (import admin): read import admin settings",
       "visible": false
     },
     {
-      "permissionName": "mod-settings.global.write.mod-inventory-update",
+      "permissionName": "mod-settings.global.write.mod-inventory-update.manage",
       "displayName": "Settings (import admin): write import admin settings",
       "visible": false
     },
@@ -960,8 +960,8 @@
         "inventory-update.import.resume-job.post",
         "inventory-update.import.init-queue.post",
 
-        "mod-settings.global.read.mod-inventory-update",
-        "mod-settings.global.write.mod-inventory-update"
+        "mod-settings.global.read.mod-inventory-update.manage",
+        "mod-settings.global.write.mod-inventory-update.manage"
 
       ]
     }

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -847,12 +847,14 @@
     {
       "permissionName": "mod-settings.global.read.mod-inventory-update.manage",
       "displayName": "Settings (import admin): read import admin settings",
-      "visible": false
+      "visible": false,
+      "replaces": ["mod-settings.global.read.mod-inventory-update"]
     },
     {
       "permissionName": "mod-settings.global.write.mod-inventory-update.manage",
       "displayName": "Settings (import admin): write import admin settings",
-      "visible": false
+      "visible": false,
+      "replaces": ["mod-settings.global.write.mod-inventory.update"]
     },
     {
       "permissionName": "modperms.inventory-update.import",

--- a/pom.xml
+++ b/pom.xml
@@ -435,7 +435,7 @@
               <goal>validate</goal>
             </goals>
             <configuration>
-              <failOnInvalidDescriptor>false</failOnInvalidDescriptor>
+              <failOnInvalidDescriptor>true</failOnInvalidDescriptor>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
 -- apply special permission names for mod-settings for compatibility
 -- switch on failOnInvalid in POM since with the new permission names it will no longer make build fail

See also: https://github.com/folio-org/mod-settings/blob/document-eurkea-permission-name-requirements/README.md#important-note-on-eureka 