### PR TITLE
MODINVUP-191 support skipping bad source file on resume

### DIFF
--- a/src/main/java/org/folio/inventoryupdate/importing/service/delivery/fileimport/FileProcessor.java
+++ b/src/main/java/org/folio/inventoryupdate/importing/service/delivery/fileimport/FileProcessor.java
@@ -51,7 +51,10 @@ public abstract class FileProcessor {
     reporting.reportFileStats();
   }
 
-  public void resume() {
+  public void resume(boolean discardFileInProcess) {
+    if (discardFileInProcess && fileListener.fileQueue.currentFile() != null) {
+      fileListener.fileQueue.deleteFile(fileListener.fileQueue.currentFile());
+    }
     importJob.logStatus(ImportJob.JobStatus.RUNNING, "", reporting.getRecordsProcessed(), configStorage);
     paused = false;
     isResuming(true);
@@ -68,6 +71,7 @@ public abstract class FileProcessor {
   public void halt(String errorMessage) {
     paused = true;
     reporting.log(errorMessage);
+    reporting.incrementFilesProcessed();
     importJob.logStatus(ImportJob.JobStatus.PAUSED, errorMessage, reporting.getRecordsProcessed(), configStorage);
     reporting.reportFileStats();
     reporting.reportFileQueueStats(false);

--- a/src/main/java/org/folio/inventoryupdate/importing/service/delivery/fileimport/XmlFileProcessor.java
+++ b/src/main/java/org/folio/inventoryupdate/importing/service/delivery/fileimport/XmlFileProcessor.java
@@ -95,7 +95,8 @@ public class XmlFileProcessor extends FileProcessor {
               promise.complete();
             } else {
               logger.error("Processing failed with {}", processing.cause().getMessage());
-              halt("Processing failed with " + processing.cause().getMessage());
+              halt("Processing of " + xmlFile.getName() + " failed with "
+                  + processing.cause().getMessage());
               promise.complete();
             }
           });

--- a/src/main/java/org/folio/inventoryupdate/importing/service/delivery/respond/JobsAndMonitoring.java
+++ b/src/main/java/org/folio/inventoryupdate/importing/service/delivery/respond/JobsAndMonitoring.java
@@ -246,6 +246,7 @@ public final class JobsAndMonitoring extends EntityResponses {
 
   public static Future<Void> resumeImportJob(ServiceRequest request) {
     String channelId = request.requestParam("id");
+    boolean discardFileInProcess = "TRUE".equalsIgnoreCase(request.requestParam("skipCurrentFile"));
     return getChannelByTagOrUuid(request, channelId).compose(channel -> {
       if (channel == null) {
         return responseText(request.routingContext(), 404)
@@ -256,7 +257,7 @@ public final class JobsAndMonitoring extends EntityResponses {
           FileProcessor processor = FileListeners
               .getFileListener(request.tenant(), channelUuid.toString()).getProcessor();
           if (processor != null && processor.paused()) {
-            processor.resume();
+            processor.resume(discardFileInProcess);
             return responseText(request.routingContext(), 200)
                 .end("Processing resumed for channel [" + channelId + "].");
           } else {

--- a/src/main/resources/openapi/inventory-import-1.0.yaml
+++ b/src/main/resources/openapi/inventory-import-1.0.yaml
@@ -332,6 +332,12 @@ paths:
         description: Channel identifier
         schema:
           type: string
+      - in: query
+        name: skipCurrentFile
+        description: if set to true, discards current file in process, resumes with next file in queue
+        required: false
+        schema:
+          type: string
     post:
       operationId: resumeJob
       description: resume file processing for a paused job in the given channel
@@ -1419,7 +1425,6 @@ components:
           format: uuid
           description: The ID of the user who most recently updated the record.
           readOnly: true
-
 
   parameters:
     okapi_tenant:

--- a/src/test/java/org/folio/inventoryupdate/unittests/ImportTests.java
+++ b/src/test/java/org/folio/inventoryupdate/unittests/ImportTests.java
@@ -1232,7 +1232,8 @@ public class ImportTests extends InventoryUpdateTestBase {
         .header(Service.OKAPI_TENANT)
         .header(Service.OKAPI_URL)
         .header(Service.OKAPI_TOKEN)
-        .post("/inventory-import/channels/" + channelId + "/resume-job?skipCurrentFile=true")
+        .queryParam("skipCurrentFile", "true")
+        .post("/inventory-import/channels/" + channelId + "/resume-job")
         .then().statusCode(200);
     await().until(() -> getRecordById(Service.PATH_IMPORT_JOBS, jobId).extract().path("status"), is("DONE"));
     assertThat("Instances in storage", fakeFolioApis.instanceStorage.getRecords().size(), is(500));

--- a/src/test/java/org/folio/inventoryupdate/unittests/ImportTests.java
+++ b/src/test/java/org/folio/inventoryupdate/unittests/ImportTests.java
@@ -1208,6 +1208,38 @@ public class ImportTests extends InventoryUpdateTestBase {
   }
 
   @Test
+  public void canSkipBadSourceFileXmlToResumeJob() {
+    configureSamplePipeline();
+    String channelId = Files.JSON_CHANNEL.getString("id");
+    String transformationId = Files.JSON_TRANSFORMATION_CONFIG.getString("id");
+    getRecordById(Service.PATH_CHANNELS, channelId);
+    getRecordById(Service.PATH_TRANSFORMATIONS, transformationId);
+
+    ArrayList<String> sourceFiles = Files.filesOfInventoryXmlRecords(5, 100, "204");
+    ArrayList<String> badSourceFiles = Files.filesOfInventoryXmlRecords(1, 100, "204");
+    String badSourceFile = badSourceFiles.getFirst().replace("</record>", "<record>");
+    sourceFiles.add(3, badSourceFile);
+    sourceFiles.forEach(xml -> postSourceXml(Service.PATH_CHANNELS + "/" + channelId + "/upload", xml, 200));
+    await().until(() -> getTotalRecords(Service.PATH_IMPORT_JOBS), is(1));
+    String jobId = getRecords(Service.PATH_IMPORT_JOBS).extract().path("importJobs[0].id");
+    await().until(() -> getTotalRecords(Service.PATH_IMPORT_JOBS), is(1));
+    await().until(() -> getRecordById(Service.PATH_IMPORT_JOBS, jobId).extract().path("status"), is("PAUSED"));
+    getRecordById(Service.PATH_IMPORT_JOBS, jobId).body("amountImported", is(300));
+    getRecordById(Service.PATH_IMPORT_JOBS, jobId).body("finished", is(nullValue()));
+    // Resume while skipping bad source file
+    given()
+        .baseUri(BASE_URI_INVENTORY_UPDATE)
+        .header(Service.OKAPI_TENANT)
+        .header(Service.OKAPI_URL)
+        .header(Service.OKAPI_TOKEN)
+        .post("/inventory-import/channels/" + channelId + "/resume-job?skipCurrentFile=true")
+        .then().statusCode(200);
+    await().until(() -> getRecordById(Service.PATH_IMPORT_JOBS, jobId).extract().path("status"), is("DONE"));
+    assertThat("Instances in storage", fakeFolioApis.instanceStorage.getRecords().size(), is(500));
+  }
+
+
+  @Test
   public void canPauseAndResumeImportJob() {
     configureSamplePipeline();
     String channelId = Files.JSON_CHANNEL.getString("id");


### PR DESCRIPTION
To be able to resume a job without immediately see it halted again in case the problem is invalid XML, it must
be possible to skip the bad file and resume from the next. 

A query parameter,  ?skipCurrentFile=true,  is being added to the  resume command to support this.