### PR TITLE
MODINVUP-208 support PUT of a channel that is GET

### DIFF
--- a/src/main/java/org/folio/inventoryupdate/importing/moduledata/Channel.java
+++ b/src/main/java/org/folio/inventoryupdate/importing/moduledata/Channel.java
@@ -130,7 +130,7 @@ public class Channel extends Entity {
     JsonObject json = new JsonObject();
     json.put(jsonPropertyName(ID), theRecord.id());
     json.put(jsonPropertyName(NAME), theRecord.name());
-    json.put(jsonPropertyName(TAG), theRecord.tag());
+    putIfNotNull(json, jsonPropertyName(TAG), theRecord.tag());
     json.put(jsonPropertyName(TYPE), theRecord.type());
     json.put(jsonPropertyName(TRANSFORMATION_ID), theRecord.transformationId());
     json.put(jsonPropertyName(ENABLED), theRecord.enabled());

--- a/src/main/java/org/folio/inventoryupdate/importing/moduledata/database/Entity.java
+++ b/src/main/java/org/folio/inventoryupdate/importing/moduledata/database/Entity.java
@@ -325,6 +325,12 @@ public abstract class Entity {
     return this;
   }
 
+  public void putIfNotNull(JsonObject json, String name, Object value) {
+    if (value != null) {
+      json.put(name, value);
+    }
+  }
+
   /**
    * Represents a field of an entity, containing JSON property name, database column name and other features of a field.
    *

--- a/src/test/java/org/folio/inventoryupdate/unittests/ImportTests.java
+++ b/src/test/java/org/folio/inventoryupdate/unittests/ImportTests.java
@@ -695,8 +695,10 @@ public class ImportTests extends InventoryUpdateTestBase {
     deleteRecord(Service.PATH_CHANNELS, Files.JSON_CHANNEL.getString("id"), 200);
     getRecords(Service.PATH_CHANNELS).body("totalRecords", is(initChannels));
 
-    // Can create disabled channel
-    postJsonObject(PATH_CHANNELS, Files.JSON_CHANNEL.copy().put("enabled", false));
+    // Can create disabled channel (this one with no tag)
+    JsonObject disabledChannel = Files.JSON_CHANNEL.copy().put("enabled", false);
+    disabledChannel.remove("tag");
+    postJsonObject(PATH_CHANNELS, disabledChannel);
     // Can only delete channel with logged jobs if `force` set to `true`
     postJsonObject(Service.PATH_IMPORT_JOBS, Files.JSON_IMPORT_JOB);
     deleteRecord(Service.PATH_CHANNELS, Files.JSON_CHANNEL.getString("id"), 400);


### PR DESCRIPTION
See problem description in https://folio-org.atlassian.net/browse/MODINVUP-208

This issue occurs after a channel is created with no tag property.  When you then GET that channel, it will contain `“tag”: null` . If you next try to PUT the channel JSON with that property, it will fail on the schema validation that says the property should be a string of a certain length. To avoid the error you would then have to remove that property first, but generally we want it to be possible to PUT an object that you retrieved with a GET. 

Ostensibly you should be able to define that the property can be null OR a string of certain format. The way to do that differs quite a bit between v3.0 and 3.1 of OpenAPI it seems. We use 3.1 but I cannot make either approach allow a property with null if it must also specify that it is a constrained string. There is a number of other scenarios where the current version of Vert.x is supporting some features of 3.1 but not all. That could very well be the case here too. 

I am opting for this:

When doing a GET, the API should remove the `tag`  property, if it is null. The channel JSON can now be PUT back as is. Of course the UI must then also itself refrain from putting a `“tag”: null`  in the PUT request. 

One consequence of the inability to send a null is, that to remove a `tag` that you have previously defined on the channel, you must PUT a JSON without the `tag` property. 