### PR TITLE
MODINVUP-210 ensure immutable IDs (primary keys)

### DIFF
--- a/src/main/java/org/folio/inventoryupdate/importing/moduledata/database/Entity.java
+++ b/src/main/java/org/folio/inventoryupdate/importing/moduledata/database/Entity.java
@@ -169,6 +169,7 @@ public abstract class Entity {
   protected String updateClauseColumnTemplates() {
     StringBuilder listOfColumnsValues = new StringBuilder();
     fields().entrySet().stream()
+        .filter(entry -> !entry.getKey().equalsIgnoreCase("id")) // Immutable.
         .filter(entry -> !entry.getValue().virtual)
         .forEach(field ->
         listOfColumnsValues.append(dbColumnName(field.getKey())).append(" = #{")


### PR DESCRIPTION
A PUT should never touch the "id" (pk) of an existing record. 