### PR TITLE
Modinvup 216 halt on fatal error

### DIFF
--- a/src/main/java/org/folio/inventoryupdate/importing/service/delivery/fileimport/InventoryBatchUpdater.java
+++ b/src/main/java/org/folio/inventoryupdate/importing/service/delivery/fileimport/InventoryBatchUpdater.java
@@ -40,12 +40,9 @@ public class InventoryBatchUpdater implements RecordReceiver {
     return this;
   }
 
-  public void startFile() {
+  public Future<Void> startFile() {
     records.clear();
     fileFinished = Promise.promise();
-  }
-
-  public Future<Void> fileFinished() {
     return fileFinished.future();
   }
 

--- a/src/main/java/org/folio/inventoryupdate/importing/service/delivery/fileimport/InventoryBatchUpdater.java
+++ b/src/main/java/org/folio/inventoryupdate/importing/service/delivery/fileimport/InventoryBatchUpdater.java
@@ -96,7 +96,8 @@ public class InventoryBatchUpdater implements RecordReceiver {
               fileProcessor.halt("Fatal error during upsert. Halting processing, skipping pending batches. "
                   + na.getMessage());
               failCurrentFile(na);
-        }).onComplete(na -> turnstile.exitBatch());
+            })
+            .onComplete(na -> turnstile.exitBatch());
       } else {
         String message = "Something is blocking the process? Could not forward batch for upsert in 60 seconds.";
         logger.error(message);

--- a/src/main/java/org/folio/inventoryupdate/importing/service/delivery/fileimport/InventoryBatchUpdater.java
+++ b/src/main/java/org/folio/inventoryupdate/importing/service/delivery/fileimport/InventoryBatchUpdater.java
@@ -94,10 +94,10 @@ public class InventoryBatchUpdater implements RecordReceiver {
             .onSuccess(na -> completeFileIfLastBatch(batch))
             .onFailure(na -> {
               logger.error("Fatal error during upsert. Pausing file processor, skipping pending batches. {}",
-              na.getMessage());
+                  na.getMessage());
               // Set job status to paused until resumed.
               fileProcessor.halt("Fatal error during upsert. Halting processing, skipping pending batches. "
-              + na.getMessage());
+                  + na.getMessage());
               failCurrentFile(na);
         }).onComplete(na -> turnstile.exitBatch());
       } else {
@@ -109,7 +109,6 @@ public class InventoryBatchUpdater implements RecordReceiver {
     } else {
       logger.info("Skipping through batch #{} because processing is halted.", batch.getBatchNumber());
       completeFileIfLastBatch(batch);
-      //turnstile.exitBatch();
     }
   }
 

--- a/src/main/java/org/folio/inventoryupdate/importing/service/delivery/fileimport/InventoryBatchUpdater.java
+++ b/src/main/java/org/folio/inventoryupdate/importing/service/delivery/fileimport/InventoryBatchUpdater.java
@@ -1,6 +1,7 @@
 package org.folio.inventoryupdate.importing.service.delivery.fileimport;
 
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
 import java.util.ArrayList;
@@ -20,6 +21,7 @@ public class InventoryBatchUpdater implements RecordReceiver {
   private final ArrayList<ProcessingRecord> records = new ArrayList<>();
   private final InventoryUpdateClient updateClient;
   private final Turnstile turnstile = new Turnstile();
+  private Promise<Void> fileFinished = Promise.promise();
   private long batchNumber;
 
   private long processingTime;
@@ -36,6 +38,19 @@ public class InventoryBatchUpdater implements RecordReceiver {
   public InventoryBatchUpdater forFileProcessor(FileProcessor processor) {
     fileProcessor = processor;
     return this;
+  }
+
+  public void startFile() {
+    records.clear();
+    fileFinished = Promise.promise();
+  }
+
+  public Future<Void> fileFinished() {
+    return fileFinished.future();
+  }
+
+  public void failCurrentFile(Throwable cause) {
+    fileFinished.tryFail(cause);
   }
 
   @Override
@@ -65,6 +80,7 @@ public class InventoryBatchUpdater implements RecordReceiver {
       if (fileProcessor.paused()) {
         logger.info("Skipping remaining pending batch ({} records) because processing has been halted",
             copyOfRecords.size());
+        fileFinished.tryComplete();
       } else {
         releaseBatch(new BatchOfRecords(copyOfRecords, true, batchNumber));
       }
@@ -74,21 +90,32 @@ public class InventoryBatchUpdater implements RecordReceiver {
   private void releaseBatch(BatchOfRecords batch) {
     if (!fileProcessor.paused()) {
       if (turnstile.enterBatch(batch)) {
-        persistBatch().onFailure(na -> {
-          logger.error("Fatal error during upsert. Pausing file processor, skipping pending batches. {}",
+        persistBatch()
+            .onSuccess(na -> completeFileIfLastBatch(batch))
+            .onFailure(na -> {
+              logger.error("Fatal error during upsert. Pausing file processor, skipping pending batches. {}",
               na.getMessage());
-          // Set job status to paused until resumed.
-          fileProcessor.halt("Fatal error during upsert. Halting processing, skipping pending batches. "
+              // Set job status to paused until resumed.
+              fileProcessor.halt("Fatal error during upsert. Halting processing, skipping pending batches. "
               + na.getMessage());
-          turnstile.exitBatch();
+              failCurrentFile(na);
         }).onComplete(na -> turnstile.exitBatch());
       } else {
-        turnstile.exitBatch();
-        logger.error("Something is blocking the process? Could not forward batch for upsert in 60 seconds.");
+        String message = "Something is blocking the process? Could not forward batch for upsert in 60 seconds.";
+        logger.error(message);
+        fileProcessor.halt(message);
+        failCurrentFile(new IllegalStateException(message));
       }
     } else {
       logger.info("Skipping through batch #{} because processing is halted.", batch.getBatchNumber());
-      turnstile.exitBatch();
+      completeFileIfLastBatch(batch);
+      //turnstile.exitBatch();
+    }
+  }
+
+  private void completeFileIfLastBatch(BatchOfRecords batch) {
+    if (batch.isLastBatchOfFile()) {
+      fileFinished.tryComplete();
     }
   }
 

--- a/src/main/java/org/folio/inventoryupdate/importing/service/delivery/fileimport/XmlFileProcessor.java
+++ b/src/main/java/org/folio/inventoryupdate/importing/service/delivery/fileimport/XmlFileProcessor.java
@@ -31,7 +31,7 @@ public class XmlFileProcessor extends FileProcessor {
 
   public static final Logger logger = LogManager.getLogger("ImportJob");
   XmlTransformationPipeline transformationPipeline;
-  RecordReceiver inventoryBatchUpdater;
+  InventoryBatchUpdater inventoryBatchUpdater;
   final Vertx vertx;
 
   public XmlFileProcessor(Vertx vertx, String tenant, UUID channelId) {
@@ -88,13 +88,21 @@ public class XmlFileProcessor extends FileProcessor {
     Promise<Void> promise = Promise.promise();
     try {
       reporting.nowProcessing(xmlFile.getName());
+      inventoryBatchUpdater.startFile();
+      Future<Void> fileFinished = inventoryBatchUpdater.fileFinished();
       String xmlFileContents = Files.readString(xmlFile.toPath(), StandardCharsets.UTF_8);
       vertx.executeBlocking(new XmlRecordsReader(xmlFileContents, transformationPipeline), true)
+          .compose(na -> fileFinished)
           .onComplete(processing -> {
             if (processing.succeeded()) {
               promise.complete();
             } else {
               logger.error("Processing failed with {}", processing.cause().getMessage());
+              if (!paused()) {
+                halt("Processing of " + xmlFile.getName() + " failed with "
+                    + processing.cause().getMessage());
+              }
+              inventoryBatchUpdater.failCurrentFile(processing.cause());
               halt("Processing of " + xmlFile.getName() + " failed with "
                   + processing.cause().getMessage());
               promise.complete();

--- a/src/main/java/org/folio/inventoryupdate/importing/service/delivery/fileimport/XmlFileProcessor.java
+++ b/src/main/java/org/folio/inventoryupdate/importing/service/delivery/fileimport/XmlFileProcessor.java
@@ -5,8 +5,6 @@ import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.UUID;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -88,10 +86,8 @@ public class XmlFileProcessor extends FileProcessor {
     Promise<Void> promise = Promise.promise();
     try {
       reporting.nowProcessing(xmlFile.getName());
-      inventoryBatchUpdater.startFile();
-      Future<Void> fileFinished = inventoryBatchUpdater.fileFinished();
-      String xmlFileContents = Files.readString(xmlFile.toPath(), StandardCharsets.UTF_8);
-      vertx.executeBlocking(new XmlRecordsReader(xmlFileContents, transformationPipeline), true)
+      Future<Void> fileFinished = inventoryBatchUpdater.startFile();
+      vertx.executeBlocking(new XmlRecordsReader(xmlFile, transformationPipeline), true)
           .compose(na -> fileFinished)
           .onComplete(processing -> {
             if (processing.succeeded()) {
@@ -103,8 +99,6 @@ public class XmlFileProcessor extends FileProcessor {
                     + processing.cause().getMessage());
               }
               inventoryBatchUpdater.failCurrentFile(processing.cause());
-              halt("Processing of " + xmlFile.getName() + " failed with "
-                  + processing.cause().getMessage());
               promise.complete();
             }
           });

--- a/src/main/java/org/folio/inventoryupdate/importing/service/delivery/fileimport/transformation/XmlRecordsReader.java
+++ b/src/main/java/org/folio/inventoryupdate/importing/service/delivery/fileimport/transformation/XmlRecordsReader.java
@@ -1,9 +1,11 @@
 package org.folio.inventoryupdate.importing.service.delivery.fileimport.transformation;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.concurrent.Callable;
 import javax.xml.parsers.ParserConfigurationException;
 import org.apache.logging.log4j.LogManager;
@@ -25,6 +27,10 @@ public class XmlRecordsReader extends DefaultHandler implements RecordProvider, 
   StringBuilder theCollectionElement = new StringBuilder();
   RecordReceiver target;
   final String xmlCollectionOfRecords;
+
+  public XmlRecordsReader(File xmlFile, RecordReceiver target) throws IOException {
+    this(Files.readString(xmlFile.toPath(), StandardCharsets.UTF_8), target);
+  }
 
   public XmlRecordsReader(String recordsSource, RecordReceiver target) {
     this.xmlCollectionOfRecords = recordsSource;

--- a/src/test/java/org/folio/inventoryupdate/unittests/ImportTests.java
+++ b/src/test/java/org/folio/inventoryupdate/unittests/ImportTests.java
@@ -1220,39 +1220,6 @@ public class ImportTests extends InventoryUpdateTestBase {
   }
 
   @Test
-  public void canSkipBadSourceFileXmlToResumeJob() {
-    configureSamplePipeline();
-    String channelId = Files.JSON_CHANNEL.getString("id");
-    String transformationId = Files.JSON_TRANSFORMATION_CONFIG.getString("id");
-    getRecordById(Service.PATH_CHANNELS, channelId);
-    getRecordById(Service.PATH_TRANSFORMATIONS, transformationId);
-
-    ArrayList<String> sourceFiles = Files.filesOfInventoryXmlRecords(5, 100, "204");
-    ArrayList<String> badSourceFiles = Files.filesOfInventoryXmlRecords(1, 100, "204");
-    String badSourceFile = badSourceFiles.getFirst().replace("</record>", "<record>");
-    sourceFiles.add(3, badSourceFile);
-    sourceFiles.forEach(xml -> postSourceXml(Service.PATH_CHANNELS + "/" + channelId + "/upload", xml, 200));
-    await().until(() -> getTotalRecords(Service.PATH_IMPORT_JOBS), is(1));
-    String jobId = getRecords(Service.PATH_IMPORT_JOBS).extract().path("importJobs[0].id");
-    await().until(() -> getTotalRecords(Service.PATH_IMPORT_JOBS), is(1));
-    await().until(() -> getRecordById(Service.PATH_IMPORT_JOBS, jobId).extract().path("status"), is("PAUSED"));
-    getRecordById(Service.PATH_IMPORT_JOBS, jobId).body("amountImported", is(300));
-    getRecordById(Service.PATH_IMPORT_JOBS, jobId).body("finished", is(nullValue()));
-    // Resume while skipping bad source file
-    given()
-        .baseUri(BASE_URI_INVENTORY_UPDATE)
-        .header(Service.OKAPI_TENANT)
-        .header(Service.OKAPI_URL)
-        .header(Service.OKAPI_TOKEN)
-        .queryParam("skipCurrentFile", "true")
-        .post("/inventory-import/channels/" + channelId + "/resume-job")
-        .then().statusCode(200);
-    await().until(() -> getRecordById(Service.PATH_IMPORT_JOBS, jobId).extract().path("status"), is("DONE"));
-    assertThat("Instances in storage", fakeFolioApis.instanceStorage.getRecords().size(), is(500));
-  }
-
-
-  @Test
   public void canPauseAndResumeImportJob() {
     configureSamplePipeline();
     String channelId = Files.JSON_CHANNEL.getString("id");
@@ -1369,6 +1336,70 @@ public class ImportTests extends InventoryUpdateTestBase {
             .post(Service.PATH_CHANNELS + "/" + channelId + "/resume-job")
             .then().statusCode(404)
             .extract().response().asPrettyString(),startsWith("Channel is not"));
+  }
+
+  @Test
+  public void willPauseOnFatalErrorAndCanResumeWithCurrentFile() {
+    configureSamplePipeline();
+    String channelId = Files.JSON_CHANNEL.getString("id");
+    String transformationId = Files.JSON_TRANSFORMATION_CONFIG.getString("id");
+    getRecordById(Service.PATH_CHANNELS, channelId);
+    getRecordById(Service.PATH_TRANSFORMATIONS, transformationId);
+
+    fakeFolioApis.instanceStorage.failOnGetRecords = true;
+    postSourceXml(Service.PATH_CHANNELS + "/" + channelId + "/upload",
+        Files.createCollectionOfInventoryXmlRecordsWithDeletes(1, 1, "200"), 200);
+
+    await().until(() -> filesInProcessingSlot(channelId), is(1));
+    await().until(() -> getTotalRecords(Service.PATH_IMPORT_JOBS), is(1));
+    String jobId = getRecords(Service.PATH_IMPORT_JOBS).extract().path("importJobs[0].id");
+    await().until(() -> getRecordById(Service.PATH_IMPORT_JOBS, jobId).extract().path("status"), is("PAUSED"));
+    assertThat("Source XML should remain available for resume", filesInProcessingSlot(channelId), is(1));
+
+    fakeFolioApis.instanceStorage.failOnGetRecords = false;
+    given()
+        .baseUri(BASE_URI_INVENTORY_UPDATE)
+        .header(Service.OKAPI_TENANT)
+        .header(Service.OKAPI_URL)
+        .header(Service.OKAPI_TOKEN)
+        .post("/inventory-import/channels/" + channelId + "/resume-job")
+        .then().statusCode(200);
+
+    await().until(() -> getRecordById(Service.PATH_IMPORT_JOBS, jobId).extract().path("status"), is("DONE"));
+    assertThat("Processing slot should be clear after successful resume", filesInProcessingSlot(channelId), is(0));
+    assertThat("Instances in storage", fakeFolioApis.instanceStorage.getRecords().size(), is(1));
+  }
+
+  @Test
+  public void canSkipBadSourceFileXmlToResumeJob() {
+    configureSamplePipeline();
+    String channelId = Files.JSON_CHANNEL.getString("id");
+    String transformationId = Files.JSON_TRANSFORMATION_CONFIG.getString("id");
+    getRecordById(Service.PATH_CHANNELS, channelId);
+    getRecordById(Service.PATH_TRANSFORMATIONS, transformationId);
+
+    ArrayList<String> sourceFiles = Files.filesOfInventoryXmlRecords(5, 100, "204");
+    ArrayList<String> badSourceFiles = Files.filesOfInventoryXmlRecords(1, 100, "204");
+    String badSourceFile = badSourceFiles.getFirst().replace("</record>", "<record>");
+    sourceFiles.add(3, badSourceFile);
+    sourceFiles.forEach(xml -> postSourceXml(Service.PATH_CHANNELS + "/" + channelId + "/upload", xml, 200));
+    await().until(() -> getTotalRecords(Service.PATH_IMPORT_JOBS), is(1));
+    String jobId = getRecords(Service.PATH_IMPORT_JOBS).extract().path("importJobs[0].id");
+    await().until(() -> getTotalRecords(Service.PATH_IMPORT_JOBS), is(1));
+    await().until(() -> getRecordById(Service.PATH_IMPORT_JOBS, jobId).extract().path("status"), is("PAUSED"));
+    getRecordById(Service.PATH_IMPORT_JOBS, jobId).body("amountImported", is(300));
+    getRecordById(Service.PATH_IMPORT_JOBS, jobId).body("finished", is(nullValue()));
+    // Resume while skipping bad source file
+    given()
+        .baseUri(BASE_URI_INVENTORY_UPDATE)
+        .header(Service.OKAPI_TENANT)
+        .header(Service.OKAPI_URL)
+        .header(Service.OKAPI_TOKEN)
+        .queryParam("skipCurrentFile", "true")
+        .post("/inventory-import/channels/" + channelId + "/resume-job")
+        .then().statusCode(200);
+    await().until(() -> getRecordById(Service.PATH_IMPORT_JOBS, jobId).extract().path("status"), is("DONE"));
+    assertThat("Instances in storage", fakeFolioApis.instanceStorage.getRecords().size(), is(500));
   }
 
   @Test
@@ -1677,6 +1708,16 @@ public class ImportTests extends InventoryUpdateTestBase {
   private void deleteFileQueues() {
     File queues = new File(System.getProperty("user.dir")+"/MIU_QUEUE");
     deleteDirectory(queues);
+  }
+
+  private int filesInProcessingSlot(String channelId) {
+      File[] files = processingSlot(channelId).listFiles(File::isFile);
+      return files == null ? 0 : files.length;
+  }
+
+  private File processingSlot(String channelId) {
+    return new File(System.getProperty("user.dir") + "/MIU_QUEUE/TENANT_" + Service.TENANT
+        + "/CHANNEL_" + channelId + "/.processing");
   }
 
   private void deleteDirectory(File directoryToBeDeleted) {

--- a/src/test/java/org/folio/inventoryupdate/unittests/fakestorage/RecordStorage.java
+++ b/src/test/java/org/folio/inventoryupdate/unittests/fakestorage/RecordStorage.java
@@ -280,24 +280,7 @@ public abstract class RecordStorage {
       failOnGetRecords = false;
       failOnUpdate = false;
       failOnCreate = false;
-      //delayGetRecordsMillis = 0L;
     }
-
-    /*
-    private boolean delayGetRecordsIfConfigured(RoutingContext routingContext) {
-        if (delayGetRecordsMillis <= 0) {
-          return true;
-        }
-        try {
-          Thread.sleep(delayGetRecordsMillis);
-          return true;
-        } catch (InterruptedException e) {
-          Thread.currentThread().interrupt();
-          respondWithMessage(routingContext, "Interrupted while delaying get records", 500);
-          return false;
-        }
-    }
-     */
 
     /**
      * Handles POST
@@ -312,7 +295,6 @@ public abstract class RecordStorage {
             respondWithMessage(routingContext, response.responseBody, response.statusCode);
         }
     }
-
 
     /**
      * Handles PUT

--- a/src/test/java/org/folio/inventoryupdate/unittests/fakestorage/RecordStorage.java
+++ b/src/test/java/org/folio/inventoryupdate/unittests/fakestorage/RecordStorage.java
@@ -274,15 +274,32 @@ public abstract class RecordStorage {
         records.clear();
     }
 
-  public void clearEnforcedFailures() {
-    failOnDelete = false;
-    failOnGetRecordById = false;
-    failOnGetRecords = false;
-    failOnUpdate = false;
-    failOnCreate = false;
-  }
+    public void clearEnforcedFailures() {
+      failOnDelete = false;
+      failOnGetRecordById = false;
+      failOnGetRecords = false;
+      failOnUpdate = false;
+      failOnCreate = false;
+      //delayGetRecordsMillis = 0L;
+    }
 
-  /**
+    /*
+    private boolean delayGetRecordsIfConfigured(RoutingContext routingContext) {
+        if (delayGetRecordsMillis <= 0) {
+          return true;
+        }
+        try {
+          Thread.sleep(delayGetRecordsMillis);
+          return true;
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          respondWithMessage(routingContext, "Interrupted while delaying get records", 500);
+          return false;
+        }
+    }
+     */
+
+    /**
      * Handles POST
      *
      */
@@ -381,25 +398,15 @@ public abstract class RecordStorage {
         routingContext.response().end();
     }
 
-    /**
-     * Respond with text message (error response)
-     *
-     * @param res error condition
-     */
-    protected static void respondWithMessage(RoutingContext routingContext, Throwable res) {
-        routingContext.response().setStatusCode(500);
-        routingContext.response().end(res.getMessage());
-    }
-
     protected static void respondWithMessage (RoutingContext routingContext, String message, int code) {
         routingContext.response().setStatusCode(code);
         routingContext.response().end(message);
 
     }
-  public Collection<FakeRecord> getRecordsInternally() {
-    return getRecords();
-  }
 
+    public Collection<FakeRecord> getRecordsInternally() {
+      return getRecords();
+    }
 
     // UTILS
 


### PR DESCRIPTION
The module can prematurely remove the current source file, after transformation but before the persisting is definitively done. In case of a fatal error during the persistence action, the file must be retained for use in a subsequent re-run. This premature removal almost exclusively affects small source files (< 100 records).

PR adds a future to the persistence logic that the overall processor can wait for until the storage is confirmed, so that the processor does not remove the processed file until then.