### PR TITLE
MODINVUP-228 Wait for done files to be removed from queue

### DIFF
--- a/src/main/java/org/folio/inventoryupdate/importing/service/delivery/fileimport/InventoryBatchUpdater.java
+++ b/src/main/java/org/folio/inventoryupdate/importing/service/delivery/fileimport/InventoryBatchUpdater.java
@@ -213,6 +213,7 @@ public class InventoryBatchUpdater implements RecordReceiver {
   private void reportEndOfFile() {
     fileProcessor.reporting.endOfFile();
     fileProcessor.fileQueueDone(true)
+        .onFailure(f -> logger.error("Error checking if file queue done {}", f.getMessage()))
         .compose(done -> {
           if (done) {
             fileProcessor.reporting.endOfQueue();

--- a/src/main/java/org/folio/inventoryupdate/importing/service/delivery/fileimport/InventoryBatchUpdater.java
+++ b/src/main/java/org/folio/inventoryupdate/importing/service/delivery/fileimport/InventoryBatchUpdater.java
@@ -217,7 +217,7 @@ public class InventoryBatchUpdater implements RecordReceiver {
           if (done) {
             fileProcessor.reporting.endOfQueue();
           }
-          return null;
+          return Future.succeededFuture(null);
         });
   }
 

--- a/src/main/java/org/folio/inventoryupdate/importing/service/delivery/fileimport/SourceFileDb.java
+++ b/src/main/java/org/folio/inventoryupdate/importing/service/delivery/fileimport/SourceFileDb.java
@@ -2,7 +2,6 @@ package org.folio.inventoryupdate.importing.service.delivery.fileimport;
 
 import io.vertx.core.Future;
 import io.vertx.sqlclient.templates.SqlTemplate;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import org.folio.inventoryupdate.importing.moduledata.database.Tables;
@@ -34,9 +33,6 @@ public class SourceFileDb implements SourceFile {
 
   @Override
   public Future<Void> discard() {
-    Map<String, Object> params = new HashMap<>();
-    params.put("channelId", channelId);
-    params.put("fileName", name);
     return SqlTemplate.forUpdate(pool.getPool(),
             "DELETE FROM " + pool.getSchema() + "." + Tables.SOURCE_FILE
                 + " WHERE file_name = #{fileName} "

--- a/src/main/java/org/folio/inventoryupdate/importing/service/delivery/fileimport/XmlFileListener.java
+++ b/src/main/java/org/folio/inventoryupdate/importing/service/delivery/fileimport/XmlFileListener.java
@@ -1,6 +1,7 @@
 package org.folio.inventoryupdate.importing.service.delivery.fileimport;
 
 import io.vertx.core.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.folio.inventoryupdate.importing.moduledata.Channel;
 import org.folio.inventoryupdate.importing.service.ImportService;
 import org.folio.inventoryupdate.importing.service.ServiceRequest;
@@ -35,25 +36,30 @@ public class XmlFileListener extends FileListener {
 
   @Override
   public void listen() {
+    AtomicBoolean clear = new AtomicBoolean(true);
     vertx.setPeriodic(200, r -> {
-      if (isListening() && !importJobPaused()) {
+      if (isListening() && !importJobPaused() && clear.get()) {
+        clear.set(false);
         boolean processorResuming = fileProcessor != null && fileProcessor.isResuming(false);
         getNextFileIfPossible(fileQueuePassive.get(), processorResuming)
             .compose(currentFile -> {
               if (currentFile != null) {  // null if queue is either empty or already has a file in progress
                 boolean queueWentFromPassiveToActive = fileQueuePassive.getAndSet(false);
                 // Continue existing job if any (= not activating), or instantiate a new (= activating).
-                getFileProcessor(queueWentFromPassiveToActive)
+                return getFileProcessor(queueWentFromPassiveToActive)
                     .compose(fileProcessor -> fileProcessor.processFile(currentFile))
-                    .onSuccess(na -> {
+                    .compose(na -> {
                       if (!importJobPaused()) { // if paused mid-file, keep file to resume
-                        currentFile.discard();
+                        return currentFile.discard().mapEmpty();
+                      } else {
+                        return Future.succeededFuture(null);
                       }
                     })
                     .onFailure(f -> logger.error("Error processing file: {}", f.getMessage()));
+              } else {
+                return Future.succeededFuture(null);
               }
-              return null;
-            });
+            }).andThen(na -> clear.set(true));
       }
     });
   }

--- a/src/main/java/org/folio/inventoryupdate/importing/service/delivery/fileimport/XmlFileListener.java
+++ b/src/main/java/org/folio/inventoryupdate/importing/service/delivery/fileimport/XmlFileListener.java
@@ -42,6 +42,7 @@ public class XmlFileListener extends FileListener {
         clear.set(false);
         boolean processorResuming = fileProcessor != null && fileProcessor.isResuming(false);
         getNextFileIfPossible(fileQueuePassive.get(), processorResuming)
+            .onFailure(f -> logger.error("Error when maybe fetching next file {}", f.getMessage()))
             .compose(currentFile -> {
               if (currentFile != null) {  // null if queue is either empty or already has a file in progress
                 boolean queueWentFromPassiveToActive = fileQueuePassive.getAndSet(false);


### PR DESCRIPTION
Also, avoid a lot of null pointer exceptions in the logs by returning `Future.succeededFuture(null)` instead of the current `null` in a couple of asynchronous invocations.